### PR TITLE
coe of V

### DIFF
--- a/src/lib/DimGeneric.ml
+++ b/src/lib/DimGeneric.ml
@@ -7,7 +7,7 @@ let make c =
   match D.compare c D.dim0 with
   | D.Same -> `Const `Dim0
   | _ ->
-    match D.compare c D.dim0 with
+    match D.compare c D.dim1 with
     | D.Same -> `Const `Dim1
     | _ -> `Ok c
 

--- a/src/lib/Val.ml
+++ b/src/lib/Val.ml
@@ -791,7 +791,7 @@ struct
             eval (R.emp ()) [Val ty00; Val ty10; Val (car equiv0); Val b] @@
             Tm.Macro.fiber (var 0) (var 1) (var 2) (var 3)
           in
-          let el0, face_front =
+          let fixer_fiber =
             let mode = `SPLIT_COERCION in (* how should we switch this? *)
             match mode with
             | `SPLIT_COERCION ->
@@ -801,69 +801,31 @@ struct
                 | `Const `Dim1 -> car (fiber0 (base1 D.dim0)), face1
                 | `Ok r_gen ->
                   let r_atom = Gen.atom r_gen in
-                  let fixer = contr0 @@
+                  contr0 @@
                     make_coe (Star.make D.dim0 r) (Abs.bind1 r_atom (fiber0_ty (base r D.dim0))) @@
                     make_cons (Val.act (D.subst D.dim0 r_atom) el, make_extlam @@ Abs.bind [Name.fresh ()] (base0 D.dim0))
-                  in
-                  let el0 = car fixer in
-                  let face_front =
-                    AbsFace.make r' D.dim0 @@
-                    let w = Name.fresh () in
-                    Abs.bind1 w (ext_apply (cdr fixer) [D.named w])
-                  in
-                  el0, face_front
               end
             | `UNIFORM_HCOM ->
-              (* favonia: because there is no (easy) way to generate Sg in the semanitc domain,
-               * the following expands hcom_Sg. *)
-              let fixer_at_face0 =
-                contr0 @@ make @@ Cons (el, make @@ ExtLam (Abs.bind [Name.fresh ()] @@ base0 D.dim0))
+              make_hcom (Star.make D.dim1 D.dim0) (fiber0_ty (base r D.dim0) (fiber0 (base r D.dim0)) @@
+              force_abs_sys @@
+              let face0 = AbsFace.make r D.dim0 @@
+                let w = Name.fresh () in
+                Abs.bind1 w @@
+                ext_apply (contr0 @@ make_cons (el, make_extlam @@ Abs.bind [Name.fresh ()] @@ base0 D.dim0)) [D.named w]
               in
-              let el0 dest =
-                make_hcom (Star.make D.dim1 dest) (Val.act (D.subst r' x) info.ty0) (car (fiber0 (base r D.dim0))) @@
-                force_abs_sys @@
-                let face0 = AbsFace.make r D.dim0 @@
-                  let w = Name.fresh () (* fourth dimension! yay! *) in
-                  Abs.bind1 w @@ car @@ ext_apply fixer_at_face0 [D.named w]
-                in
-                let face1 =
-                  AbsFace.make r D.dim1 @@
-                  Abs.bind [Name.fresh ()] (car (fiber0 (base1 D.dim0)))
-                in
-                [face0; face1]
+              let face1 = AbsFace.make r D.dim1 @@
+                Abs.bind [Name.fresh ()] (fiber0 (base1 D.dim0))
               in
-              (* favonia: not sure if using Path types to compress is a win. *)
-              let face_front =
-                AbsFace.make r' D.dim0 @@
-                let z = Name.fresh () in
-                Abs.bind1 z @@
-                let ty =
-                  let w = Name.fresh () in
-                  Abs.bind1 w @@
-                  make_path
-                    (Abs.bind [Name.fresh ()] (Val.act (D.subst D.dim0 x) info.ty1))
-                    (apply (car equiv0) (el0 (D.named w)))
-                    (base r D.dim0)
-                in
-                let com =
-                  make_com (Star.make D.dim1 D.dim0) ty (cdr (fiber0 (base r D.dim0))) @@
-                  force_abs_sys @@
-                  let face0 = AbsFace.make r D.dim0 @@
-                    let w = Name.fresh () (* fourth dimension! yay! *) in
-                    Abs.bind1 w @@
-                    cdr @@ ext_apply fixer_at_face0 [D.named w]
-                  in
-                  let face1 = AbsFace.make r D.dim1 @@
-                    Abs.bind [Name.fresh ()] (cdr (fiber0 (base1 D.dim0)))
-                  in
-                  [face0; face1]
-                in
-                ext_apply com [D.named z]
-              in
-              (el0 D.dim1, face_front)
+              [face0; face1]
             | `UNICORN ->
               failwith "too immortal; not suitable for mortal beings"
           in
+          let el0 = car fixer_fiber in
+          let face_front =
+            AbsFace.make r' D.dim0 @@
+            let w = Name.fresh () in
+            Abs.bind1 w @@
+            ext_apply (cdr fixer_fiber) [D.named w]
           let el1 = make_hcom (Star.make D.dim1 D.dim0) info.ty1 (base r r') @@
             force_abs_sys [face0; face1; face_diag; face_front]
           in

--- a/src/lib/Val.ml
+++ b/src/lib/Val.ml
@@ -784,14 +784,14 @@ struct
             match mode with
             | `SPLIT_COERCION ->
               begin
-                match Gen.make r with
-                | `Const `Dim0 -> el, face0
-                | `Const `Dim1 -> car (fiber0 (base1 D.dim0)), face1
-                | `Ok r_gen ->
+                match D.unleash r (* favonia: is this really okay?! *) with
+                | D.Dim0 -> el, face0
+                | D.Dim1 -> car (fiber0 (base1 D.dim0)), face1
+                | D.Atom r_atom ->
                   let fixer =
                     let el0 dest =
                       make_coe (Star.make D.dim0 dest) abs0 @@
-                      failwith "how should I implement `Val.act (D.subst D.dim0 r_gen) el`?!"
+                      Val.act (D.subst D.dim0 r_atom) el
                     in
                     let el1 dest =
                       let ty =

--- a/src/lib/Val.ml
+++ b/src/lib/Val.ml
@@ -630,9 +630,6 @@ struct
     | `Const `Dim1 ->
       ty1
 
-  and rigid_vin x el0 el1 : value =
-    make @@ VIn {x; el0; el1}
-
   and make_vin mgen el0 el1 : value =
     match mgen with
     | `Ok x ->
@@ -731,6 +728,9 @@ struct
       end
     | `Same _ ->
       cap
+
+  and rigid_vin x el0 el1 : value =
+    make @@ VIn {x; el0; el1}
 
   and rigid_coe dir abs el =
     let x, tyx = Abs.unleash1 abs in

--- a/src/lib/Val.ml
+++ b/src/lib/Val.ml
@@ -845,70 +845,37 @@ struct
           make_vin (Gen.make r') el0 el1
 
         | D.Apart ->
-          failwith "wow"
+          let abs0 = Abs.bind1 x info.ty0 in
+          let el0 = rigid_coe dir abs0 el in
+          let el1 =
+            let cap =
+              let phi = Dim.subst r x in
+              let ty0r = Val.act phi info.ty0 in
+              let ty1r = Val.act phi info.ty1 in
+              let equivr = Val.act phi info.equiv in
+              rigid_vproj info.x ~el ~ty0:ty0r ~ty1:ty1r ~equiv:equivr
+            in
+            let r2x = Star.make r (D.named x) in
+            let sys =
+              let face0 =
+                AbsFace.gen_const info.x `Dim0 @@
+                Abs.bind1 x @@ apply (car info.equiv) @@
+                make_coe r2x abs0 el
+              in
+              let face1 =
+                AbsFace.gen_const info.x `Dim1 @@
+                Abs.bind1 x @@
+                make_coe r2x abs1 el
+              in
+              [face0; face1]
+            in
+            rigid_com dir abs1 cap sys
+          in
+          rigid_vin info.x el0 el1
+
         | D.Indeterminate ->
           failwith "impossible"
       end
-      (*
-        match Gen.make r with
-        | `Const `Dim0 ->
-          make_vin (Gen.make r') el el1
-
-        | `Const `Dim1 ->
-          let coe1r'el = rigid_coe dir xty1 el in
-          let el0 = car @@ apply (cdr @@ Val.act (D.subst r' x) info.equiv) coe1r'el in
-          let el1 =
-            let ty1r' = Val.act (D.subst r' x) info.ty1 in
-            let cap = coe1r'el in
-            let sys =
-              force_abs_sys @@
-              let face0 =
-                AbsFace.make r' D.dim0 @@
-                let y = Name.fresh () in
-                Abs.bind1 y @@ ext_apply (cdr el0) [D.named y]
-              in
-              let face1 = AbsFace.make r' D.dim1 @@ Abs.bind [Name.fresh ()] coe1r'el in
-              [face0; face1]
-            in
-            make_hcom (Star.make D.dim1 D.dim0) ty1r' cap sys
-          in
-          make_vin (Gen.make r') (car el0) el1
-
-        | `Ok _ ->
-          begin
-              failwith "This is the hard one"
-
-            | _ ->
-              let xty0 = Abs.bind1 x info.ty0 in
-              let el0 = rigid_coe dir xty0 el in
-              let el1 =
-                let cap =
-                  let phi = Dim.subst r x in
-                  let ty0r = Val.act phi info.ty0 in
-                  let ty1r = Val.act phi info.ty1 in
-                  let equivr = Val.act phi info.equiv in
-                  rigid_vproj info.x ~el ~ty0:ty0r ~ty1:ty1r ~equiv:equivr
-                in
-                let r2x = Star.make r (D.named x) in
-                let sys =
-                  let face0 =
-                    AbsFace.gen_const info.x `Dim0 @@
-                    Abs.bind1 x @@ apply (car info.equiv) @@
-                    make_coe r2x xty0 el
-                  in
-                  let face1 =
-                    AbsFace.gen_const info.x `Dim1 @@
-                    Abs.bind1 x @@
-                    make_coe r2x xty1 el
-                  in
-                  [face0; face1]
-                in
-                rigid_com dir xty1 cap sys
-              in
-              make @@ VIn {x = info.x; el0; el1}
-          end
-      end
-      *)
 
     | _ ->
       failwith "TODO: rigid_coe"

--- a/src/lib/Val.ml
+++ b/src/lib/Val.ml
@@ -784,10 +784,11 @@ struct
             match mode with
             | `SPLIT_COERCION ->
               begin
-                match D.unleash r (* favonia: is this really okay?! *) with
-                | D.Dim0 -> el, face0
-                | D.Dim1 -> car (fiber0 (base1 D.dim0)), face1
-                | D.Atom r_atom ->
+                match Gen.make r with
+                | `Const `Dim0 -> el, face0
+                | `Const `Dim1 -> car (fiber0 (base1 D.dim0)), face1
+                | `Ok r_gen ->
+                  let r_atom = Gen.atom r_gen in
                   let fixer =
                     let el0 dest =
                       make_coe (Star.make D.dim0 dest) abs0 @@


### PR DESCRIPTION
Fix RedPRL/redtt#42. The current code is actually incorrect---the 0/1 cases only make sense when `x=y` in `x.V_y(...)`.

What is the immortal way to have alternative dynamics? @jonsterling