### PR TITLE
eta law for v types

### DIFF
--- a/connection.red
+++ b/connection.red
@@ -18,7 +18,7 @@ let connection/or
    end
  =
  λ i j →
-  ; this is an example of something that is much nicer here than in redprl and yacctt.
+  ; this is an example of something that is much nicer here than in redprl.
   ; we can define using line types all the faces of the composition at once.
   ; definitional equivalence kicks in to make this work.
   let face : Line (Line A) =

--- a/path.red
+++ b/path.red
@@ -12,6 +12,22 @@ let Path
   | i=1 ⇒ N
   end
 
+let Square
+  (A : type)
+  (a0 : A) (a1 : A) (b0 : A) (b1 : A)
+  (M : Path A a0 a1)
+  (N : Path A b0 b1)
+  (O : Path A a0 b0)
+  (P : Path A a1 b1)
+  : type
+  =
+  [i j] A with
+  | j=0 ⇒ M i
+  | j=1 ⇒ N i
+  | i=0 ⇒ O j
+  | i=1 ⇒ P j
+  end
+
 
 let funext
   (A : type)
@@ -24,15 +40,44 @@ let funext
   λ i x →
     p x i
 
+let symm/filler
+  (A : type)
+  (p : Line A)
+  : Line (Line A)
+  =
+  λ j i →
+    comp 0 j (p 0) with
+    | i=0 ⇒ λ i → p i
+    | i=1 ⇒ λ _ → p 0
+    end
+
 let symm
   (A : type)
   (p : Line A)
   : Path A (p 1) (p 0)
   =
   λ i →
-    comp 0 1 (p 0) with
-    | i=0 ⇒ λ i → p i
-    | i=1 ⇒ λ _ → p 0
+    symm/filler A p 1 i
+
+let symm/unit
+  (A : type)
+  (a : A)
+  : (Path (Path A a a) (λ _ → a) (symm A (λ _ → a)))
+  =
+  λ i j →
+    symm/filler A (λ _ → a) i j
+
+let trans/filler
+  (A : type)
+  (x : A)
+  (p : Line A)
+  (q : Path A (p 1) x)
+  : Line (Line A)
+  =
+  λ j i →
+    comp 0 j (p i) with
+    | i=0 ⇒ λ _ → p 0
+    | i=1 ⇒ λ i → q i
     end
 
 let trans
@@ -43,7 +88,43 @@ let trans
   : Path A (p 0) (q 1)
   =
   λ i →
+    trans/filler A x p q 1 i
+
+let trans/unit/r
+  (A : type)
+  (p : Line A)
+  : Path (Path A (p 0) (p 1)) (λ i → p i) (trans A (p 1) p (λ _ → p 1))
+  =
+  λ i j →
+    trans/filler A (p 1) p (λ _ → p 1) i j
+
+; This proof gets simpler when dead tubes are deleted!
+let trans/sym/r
+  (A : type)
+  (p : Line A)
+  : Path (Path A (p 0) (p 0)) (λ _ → p 0) (trans A (p 0) p (symm A p))
+  =
+  λ k i →
     comp 0 1 (p i) with
     | i=0 ⇒ λ _ → p 0
-    | i=1 ⇒ λ i → q i
+    | i=1 ⇒ λ j → symm A p j
+    | k=0 ⇒ λ j → symm/filler A p i j
+    ;| k=1 ⇒ λ j → trans/filler A (p 0) p (symm A p) j i
     end
+
+; Define LineD and PathD?
+; Perhaps we could parallelize this proof? ;)
+let symmd
+  (A : Line^1 type)
+  (p : [i] A i with end)
+  : [i] (symm^1 type A) i with
+    | i=0 ⇒ p 1
+    | i=1 ⇒ p 0
+    end
+  =
+  λ i →
+    ?todo
+    ;comp 0 1 (p 0) in (λ j → symm/filler^1 type A j i) with
+    ;| i=0 ⇒ λ j → p j
+    ;| i=1 ⇒ λ _ → p 0
+    ;end

--- a/path.red
+++ b/path.red
@@ -123,8 +123,7 @@ let symmd
     end
   =
   λ i →
-    ?todo
-    ;comp 0 1 (p 0) in (λ j → symm/filler^1 type A j i) with
-    ;| i=0 ⇒ λ j → p j
-    ;| i=1 ⇒ λ _ → p 0
-    ;end
+    comp 0 1 (p 0) in (λ j → symm/filler^1 type A j i) with
+    | i=0 ⇒ λ j → p j
+    | i=1 ⇒ λ _ → p 0
+    end

--- a/src/core/I.ml
+++ b/src/core/I.ml
@@ -31,6 +31,7 @@ let swap a b = Swap (a, b)
 let subst r a = Subst (r, a)
 let cmp phi1 phi0 = Cmp (phi1, phi0)
 
+
 exception Inconsistent
 
 let equate r0 r1 =
@@ -107,3 +108,15 @@ let pp fmt =
     Format.fprintf fmt "1"
   | `Atom x ->
     Name.pp fmt x
+
+
+let rec pp_action fmt =
+  function
+  | Idn ->
+    Format.fprintf fmt "idn"
+  | Swap (a, b) ->
+    Format.fprintf fmt "%a <-> %a" Name.pp a Name.pp b
+  | Subst (r, x) ->
+    Format.fprintf fmt "[%a/%a]" pp r Name.pp x
+  | Cmp (phi1, phi0) ->
+    Format.fprintf fmt "%a o %a" pp_action phi1 pp_action phi0

--- a/src/core/I.mli
+++ b/src/core/I.mli
@@ -36,6 +36,7 @@ val absent : atom -> t -> bool
 
 
 val pp : t Pretty.t0
+val pp_action : action Pretty.t0
 
 
 exception Inconsistent

--- a/src/core/LocalCx.ml
+++ b/src/core/LocalCx.ml
@@ -142,7 +142,14 @@ struct
     let r = I.act phi r in
     let r' = I.act phi r' in
     let rel, phi = Restriction.equate r r' cx.rel in
-    {cx with rel; env = V.Env.act phi cx.env}, phi
+    let act_ty =
+      function
+      | `Ty ty -> `Ty (V.Val.act phi ty)
+      | `Dim -> `Dim
+    in
+    let tys = List.map act_ty cx.tys in
+    let env = V.Env.act phi cx.env in
+    {cx with rel; tys; env}, phi
 
 
   let quote cx ~ty el =

--- a/src/core/LocalCx.ml
+++ b/src/core/LocalCx.ml
@@ -19,6 +19,7 @@ sig
   type value = Val.value
 
   val emp : t
+  val clear : t -> t
 
   val ext_ty : t -> nm:string option -> value -> t * value
   val ext_dim : t -> nm:string option -> t * I.atom
@@ -63,6 +64,9 @@ struct
      tys = [];
      ppenv = Pretty.Env.emp;
      rel = V.base_restriction}
+
+  let clear cx =
+    {emp with rel = cx.rel; env = Eval.Env.clear cx.env}
 
   let ext {env; qenv; tys; ppenv; rel} ~nm ty sys =
     let n = Quote.Env.len qenv in

--- a/src/core/LocalCx.ml
+++ b/src/core/LocalCx.ml
@@ -181,6 +181,11 @@ struct
 
   let check_subtype cx ty0 ty1 =
     try
+      (* The following must be masking a bug!! *)
+      let tty0 = quote_ty cx ty0 in
+      let tty1 = quote_ty cx ty1 in
+      let ty0 = eval cx tty0 in
+      let ty1 = eval cx tty1 in
       Q.subtype cx.qenv ty0 ty1
     with
     | exn ->

--- a/src/core/LocalCx.ml
+++ b/src/core/LocalCx.ml
@@ -181,11 +181,10 @@ struct
 
   let check_subtype cx ty0 ty1 =
     try
-      (* The following must be masking a bug!! *)
-      let tty0 = quote_ty cx ty0 in
-      let tty1 = quote_ty cx ty1 in
-      let ty0 = eval cx tty0 in
-      let ty1 = eval cx tty1 in
+      (* The following masks a bug !!!! *)
+      let phi = Restriction.as_action cx.rel in
+      let ty0 = V.Val.act phi ty0 in
+      let ty1 = V.Val.act phi ty1 in
       Q.subtype cx.qenv ty0 ty1
     with
     | exn ->

--- a/src/core/LocalCx.ml
+++ b/src/core/LocalCx.ml
@@ -181,10 +181,6 @@ struct
 
   let check_subtype cx ty0 ty1 =
     try
-      (* The following masks a bug !!!! *)
-      let phi = Restriction.as_action cx.rel in
-      let ty0 = V.Val.act phi ty0 in
-      let ty1 = V.Val.act phi ty1 in
       Q.subtype cx.qenv ty0 ty1
     with
     | exn ->

--- a/src/core/LocalCx.ml
+++ b/src/core/LocalCx.ml
@@ -19,7 +19,7 @@ sig
   type value = Val.value
 
   val emp : t
-  val clear : t -> t
+  val clear_locals : t -> t
 
   val ext_ty : t -> nm:string option -> value -> t * value
   val ext_dim : t -> nm:string option -> t * I.atom
@@ -65,8 +65,8 @@ struct
      ppenv = Pretty.Env.emp;
      rel = V.base_restriction}
 
-  let clear cx =
-    {emp with rel = cx.rel; env = Eval.Env.clear cx.env}
+  let clear_locals cx =
+    {emp with rel = cx.rel; env = Eval.Env.clear_locals cx.env}
 
   let ext {env; qenv; tys; ppenv; rel} ~nm ty sys =
     let n = Quote.Env.len qenv in

--- a/src/core/LocalCx.mli
+++ b/src/core/LocalCx.mli
@@ -10,6 +10,7 @@ sig
   type value = Val.value
 
   val emp : t
+  val clear : t -> t
 
   val ext_ty : t -> nm:string option -> value -> t * value
   val ext_dim : t -> nm:string option -> t * I.atom

--- a/src/core/LocalCx.mli
+++ b/src/core/LocalCx.mli
@@ -10,7 +10,7 @@ sig
   type value = Val.value
 
   val emp : t
-  val clear : t -> t
+  val clear_locals : t -> t
 
   val ext_ty : t -> nm:string option -> value -> t * value
   val ext_dim : t -> nm:string option -> t * I.atom

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -147,8 +147,6 @@ struct
       let tm1 = equate env info.ty1 vproj0 vproj1 in
       Tm.make @@ Tm.VIn {r = tr; tm0; tm1}
 
-    (* TODO: V type, in order to get eta law *)
-
     | _ ->
       match unleash el0, unleash el1 with
       | Univ info0, Univ info1 ->
@@ -209,16 +207,6 @@ struct
         let equiv_ty = V.Macro.equiv info0.ty0 info1.ty1 in
         let equiv = equate env equiv_ty info0.equiv info1.equiv in
         Tm.make @@ Tm.V {r = tr; ty0; ty1; equiv}
-
-      | VIn info0, VIn info1 ->
-        (* Format.eprintf "Quoting VIn: %a = %a@." pp_value el0 pp_value el1; *)
-        let x, ty0, ty1, _ = unleash_v ty in
-        let r = `Atom x in
-        let tr = quote_dim env r in
-        let ty0r0 = Val.act (I.equate r `Dim0) ty0 in
-        let tm0 = equate env ty0r0 info0.el0 info1.el0 in
-        let tm1 = equate env ty1 info0.el1 info1.el1 in
-        Tm.make @@ Tm.VIn {r = tr; tm0; tm1}
 
       | Box info0, Box info1 ->
         let dir, ty_cap, ty_sys = unleash_fcom ty in

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -138,6 +138,15 @@ struct
       let qcall = equate env ty call0 call1 in
       Tm.make @@ Tm.LblRet qcall
 
+    | V info ->
+      let tr = quote_dim env @@ `Atom info.x in
+      let phi_r0 = I.subst `Dim0 info.x in
+      let tm0 = equate env (Val.act phi_r0 info.ty0) (Val.act phi_r0 el0) (Val.act phi_r0 el1) in
+      let vproj0 = rigid_vproj info.x ~ty0:info.ty0 ~ty1:info.ty1 ~equiv:info.equiv ~el:el0 in
+      let vproj1 = rigid_vproj info.x ~ty0:info.ty0 ~ty1:info.ty1 ~equiv:info.equiv ~el:el1 in
+      let tm1 = equate env info.ty1 vproj0 vproj1 in
+      Tm.make @@ Tm.VIn {r = tr; tm0; tm1}
+
     (* TODO: V type, in order to get eta law *)
 
     | _ ->

--- a/src/core/Tm.ml
+++ b/src/core/Tm.ml
@@ -820,9 +820,8 @@ and pp_cmd env fmt (hd, sp) =
         let x_mot, env_mot = Pretty.Env.bind nm_mot env in
         let x_lcase, env_lcase = Pretty.Env.bind nm_lcase env in
         Format.fprintf fmt "@[<hv1>(S1rec@ [%a] %a@ %a %a [%a] %a)@]" Uuseg_string.pp_utf_8 x_mot (pp env_mot) mot (go `S1Rec) sp (pp env) bcase Uuseg_string.pp_utf_8 x_lcase (pp env_lcase) lcase
-      | VProj {r; _} ->
-        (* TODO *)
-        Format.fprintf fmt "@[<hv1>(vproj %a@ %a)@]" (pp env) r (go `VProj) sp
+      | VProj {r; ty0; ty1; equiv} ->
+        Format.fprintf fmt "@[<hv1>(vproj %a@ %a@ %a@ %a@ %a)@]" (pp env) r (go `VProj) sp (pp env) ty0 (pp env) ty1 (pp env) equiv
       | Cap _ ->
         (* FIXME *)
         Format.fprintf fmt "@<cap>"
@@ -831,7 +830,6 @@ and pp_cmd env fmt (hd, sp) =
       | CoRForce ->
         Format.fprintf fmt "@[<hv1>(force@ %a)@]" (go `Force) sp
   in
-  (* TODO: backwards ??? *)
   go `Start fmt sp
 
 and pp_spine env fmt sp =

--- a/src/core/Tm.ml
+++ b/src/core/Tm.ml
@@ -659,7 +659,7 @@ let rec pp env fmt =
       Format.fprintf fmt "@[<hv1>(V %a@ %a@ %a@ %a)@]" (pp env) info.r (pp env) info.ty0 (pp env) info.ty1 (pp env) info.equiv
 
     | VIn info ->
-      Format.fprintf fmt "@[<hv1>(Vin %a@ %a@ %a)!]" (pp env) info.r (pp env) info.tm0 (pp env) info.tm1
+      Format.fprintf fmt "@[<hv1>(Vin %a@ %a@ %a)@]" (pp env) info.r (pp env) info.tm0 (pp env) info.tm1
 
     | Lam (B (nm, tm)) ->
       let x, env' = Pretty.Env.bind nm env in

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -237,6 +237,19 @@ struct
     | V.Bool, (T.Tt | T.Ff) ->
       ()
 
+    | V.V vty, T.VIn vin ->
+      let r = check_eval_dim cx vin.r in
+      begin
+        match I.compare (`Atom vty.x) r with
+        | `Same ->
+          let cx', phi = Cx.restrict cx (`Atom vty.x) `Dim0 in
+          let el0 = check_eval cx' vty.ty0 vin.tm0 in
+          let el1 = check_eval cx vty.ty1 vin.tm1 in
+          Cx.check_eq cx' ~ty:(Eval.Val.act phi vty.ty1) (Eval.apply (Eval.car vty.equiv) el0) @@ Eval.Val.act phi el1
+        | _ ->
+          failwith "v/vin dimension mismatch"
+      end
+
     | _, T.Up tm ->
       let ty' = infer cx tm in
       Cx.check_subtype cx ty' ty

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -534,10 +534,7 @@ struct
     function
     | T.Ref {name; twin; ushift} ->
       let ty = Tm.shift_univ ushift @@ GlobalEnv.lookup_ty Sig.globals name twin in
-      (* The following appears to mask a bug!! *)
-      let ty = Cx.eval Cx.emp ty in
-      let ty = Cx.quote_ty cx ty in
-      Cx.eval cx ty
+      Cx.eval (Cx.clear cx) ty
 
     | T.Ix (ix, _) ->
       begin

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -305,8 +305,9 @@ struct
       let r, r' = IStar.unleash p in
       try
         let cx', phi = Cx.restrict cx r r' in
-        Cx.check_eq cx' ~ty:(Eval.Val.act phi ty) el @@
-        Cx.eval cx' tm
+        Cx.check_eq cx' ~ty:(Eval.Val.act phi ty) (Eval.Val.act phi el) @@
+        (* TODO: it is strange that I need this. Seems to uncover either a bug of a conceptual misunderstanding on my part. - Jon *)
+        Eval.Val.act phi @@ Cx.eval cx' tm
       with
       | I.Inconsistent ->
         ()

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -305,9 +305,8 @@ struct
       let r, r' = IStar.unleash p in
       try
         let cx', phi = Cx.restrict cx r r' in
-        Cx.check_eq cx' ~ty:(Eval.Val.act phi ty) (Eval.Val.act phi el) @@
-        (* TODO: it is strange that I need this. Seems to uncover either a bug of a conceptual misunderstanding on my part. - Jon *)
-        Eval.Val.act phi @@ Cx.eval cx' tm
+        Cx.check_eq cx' ~ty:(Eval.Val.act phi ty) el @@
+        Cx.eval cx' tm
       with
       | I.Inconsistent ->
         ()

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -534,7 +534,10 @@ struct
     function
     | T.Ref {name; twin; ushift} ->
       let ty = Tm.shift_univ ushift @@ GlobalEnv.lookup_ty Sig.globals name twin in
-      Cx.eval Cx.emp ty
+      (* The following appears to mask a bug!! *)
+      let ty = Cx.eval Cx.emp ty in
+      let ty = Cx.quote_ty cx ty in
+      Cx.eval cx ty
 
     | T.Ix (ix, _) ->
       begin

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -533,7 +533,7 @@ struct
     function
     | T.Ref {name; twin; ushift} ->
       let ty = Tm.shift_univ ushift @@ GlobalEnv.lookup_ty Sig.globals name twin in
-      Cx.eval (Cx.clear cx) ty
+      Cx.eval (Cx.clear_locals cx) ty
 
     | T.Ix (ix, _) ->
       begin
@@ -544,7 +544,7 @@ struct
 
     | T.Meta {name; ushift} ->
       let ty = Tm.shift_univ ushift @@ GlobalEnv.lookup_ty Sig.globals name `Only in
-      Cx.eval Cx.emp ty
+      Cx.eval (Cx.clear_locals cx) ty
 
     | T.Coe info ->
       let r = check_eval_dim cx info.r in

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -155,6 +155,7 @@ sig
       with type t = env
       with type 'a m = 'a
     val emp : env
+    val clear : env -> env
     val push : env_el -> env -> env
   end
 

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -155,7 +155,7 @@ sig
       with type t = env
       with type 'a m = 'a
     val emp : env
-    val clear : env -> env
+    val clear_locals : env -> env
     val push : env_el -> env -> env
   end
 
@@ -229,7 +229,7 @@ struct
 
     let emp = {cells = []; global = I.idn}
 
-    let clear rho =
+    let clear_locals rho =
       {rho with cells = []}
 
     let push el {cells; global} =
@@ -1626,14 +1626,14 @@ struct
 
     | Tm.Ref info ->
       let tty, tsys = Sig.lookup info.name info.twin in
-      let rho' = Env.clear rho in
+      let rho' = Env.clear_locals rho in
       let vsys = eval_tm_sys rho' @@ Tm.map_tm_sys (Tm.shift_univ info.ushift) tsys in
       let vty = eval rho' @@ Tm.shift_univ info.ushift tty in
       reflect vty (Ref {name = info.name; twin = info.twin; ushift = info.ushift}) vsys
 
     | Tm.Meta {name; ushift} ->
       let tty, tsys = Sig.lookup name `Only in
-      let rho' = Env.clear rho in
+      let rho' = Env.clear_locals rho in
       let vsys = eval_tm_sys rho' @@ Tm.map_tm_sys (Tm.shift_univ ushift) tsys in
       let vty = eval rho' @@ Tm.shift_univ ushift tty in
       reflect vty (Meta {name; ushift}) vsys

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -228,6 +228,9 @@ struct
 
     let emp = {cells = []; global = I.idn}
 
+    let clear rho =
+      {rho with cells = []}
+
     let push el {cells; global} =
       {cells = el :: cells; global}
 
@@ -1622,14 +1625,16 @@ struct
 
     | Tm.Ref info ->
       let tty, tsys = Sig.lookup info.name info.twin in
-      let vsys = eval_tm_sys Env.emp @@ Tm.map_tm_sys (Tm.shift_univ info.ushift) tsys in
-      let vty = eval Env.emp @@ Tm.shift_univ info.ushift tty in
+      let rho' = Env.clear rho in
+      let vsys = eval_tm_sys rho' @@ Tm.map_tm_sys (Tm.shift_univ info.ushift) tsys in
+      let vty = eval rho' @@ Tm.shift_univ info.ushift tty in
       reflect vty (Ref {name = info.name; twin = info.twin; ushift = info.ushift}) vsys
 
     | Tm.Meta {name; ushift} ->
       let tty, tsys = Sig.lookup name `Only in
-      let vsys = eval_tm_sys Env.emp @@ Tm.map_tm_sys (Tm.shift_univ ushift) tsys in
-      let vty = eval Env.emp @@ Tm.shift_univ ushift tty in
+      let rho' = Env.clear rho in
+      let vsys = eval_tm_sys rho' @@ Tm.map_tm_sys (Tm.shift_univ ushift) tsys in
+      let vty = eval rho' @@ Tm.shift_univ ushift tty in
       reflect vty (Meta {name; ushift}) vsys
 
   and reflect ty neu sys =

--- a/src/core/Val.mli
+++ b/src/core/Val.mli
@@ -148,7 +148,7 @@ sig
       with type t = env
       with type 'a m = 'a
     val emp : env
-    val clear : env -> env
+    val clear_locals : env -> env
     val push : env_el -> env -> env
   end
 

--- a/src/core/Val.mli
+++ b/src/core/Val.mli
@@ -148,6 +148,7 @@ sig
       with type t = env
       with type 'a m = 'a
     val emp : env
+    val clear : env -> env
     val push : env_el -> env -> env
   end
 

--- a/src/frontend/Dev.ml
+++ b/src/frontend/Dev.ml
@@ -270,7 +270,7 @@ let pp_entry fmt =
       Tm.pp0 ty
 
   | E (x, ty, Guess {tm; ty = ty'}) ->
-    Format.fprintf fmt "?%a@ :@ %a =? %a : %a"
+    Format.fprintf fmt "@[<hv1>?%a@ :@ %a =?@ %a@ :@ %a@]"
       Name.pp x
       Tm.pp0 ty
       Tm.pp0 tm

--- a/src/frontend/ESig.ml
+++ b/src/frontend/ESig.ml
@@ -10,6 +10,8 @@ and ecell = string * eterm
 and etele = ecell list
 
 and eterm =
+  | Guess of eterm
+
   | Hole of string option
   | Hope
   | Lam of string list * eterm

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -73,7 +73,7 @@ struct
       elab_decl env (E.Debug f) >>= fun env' ->
       elab_sig env' esig
     | dcl :: esig ->
-      M.isolate (elab_decl env dcl) >>= fun env' ->
+      elab_decl env dcl >>= fun env' ->
       elab_sig env' esig
 
 
@@ -132,6 +132,11 @@ struct
   and elab_chk env ty e : tm M.m =
     normalize_ty ty >>= fun ty ->
     match Tm.unleash ty, e with
+    | Tm.Rst rst, E.Guess e ->
+      elab_chk env rst.ty e >>= fun tm ->
+      M.lift C.ask >>= fun psi ->
+      M.lift @@ U.push_guess psi ~ty0:ty ~ty1:rst.ty tm
+
     | _, E.Hole name ->
       M.lift C.ask >>= fun psi ->
       M.lift @@ U.push_hole `Rigid psi ty >>= fun tm ->
@@ -419,12 +424,11 @@ struct
     elab_inf env inf >>= fun (ty', cmd) ->
     M.lift (C.check_subtype ty' ty) >>= fun b ->
     if b then M.ret @@ Tm.up cmd else
-      (* TODO: I really don't like this; it leads to confusing, RedPRL-style proof states where you don't know if you're wrong.
-         We should be more conservative, and try to immediately solve the problem with unification, and if that fails, throw an error. *)
       begin
         M.lift @@ C.active @@ Dev.Subtype {ty0 = ty'; ty1 = ty} >>
-        M.lift C.ask >>= fun psi ->
-        M.lift @@ U.push_guess psi ~ty0:ty ~ty1:ty' (Tm.up cmd)
+        M.unify >>
+        M.lift (C.check_subtype ty' ty) >>= fun b ->
+        if b then M.ret (Tm.up cmd) else failwith "type error"
       end
 
   and elab_inf env e : (ty * tm Tm.cmd) M.m =
@@ -529,9 +533,9 @@ struct
                 if b then M.ret (Tm.up (hd, sp)) else
                   let tm = Tm.up (hd, sp) in
                   M.lift @@ C.active @@ Dev.Subtype {ty0 = hty; ty1 = ty} >>
-                  M.lift C.ask >>= fun psi ->
-                  M.lift @@ U.push_guess psi ~ty0:ty ~ty1:hty tm >>= fun tm ->
-                  M.ret tm
+                  M.unify >>
+                  M.lift (C.check_subtype hty ty) >>= fun b ->
+                  if b then M.ret tm else failwith "elab_cut: type error"
 
               | Inf ->
                 M.ret (hty, (hd, sp))

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -135,7 +135,10 @@ struct
     | _, E.Hole name ->
       M.lift C.ask >>= fun psi ->
       M.lift @@ U.push_hole `Rigid psi ty >>= fun tm ->
-      M.emit @@ M.UserHole {name; ty; tele = psi; tm = Tm.up tm} >>
+      begin
+        if name = Some "_" then M.ret () else
+          M.emit @@ M.UserHole {name; ty; tele = psi; tm = Tm.up tm}
+      end >>
       M.ret @@ Tm.up tm
 
     | _, E.Hope ->

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -562,7 +562,14 @@ struct
                 failwith "elab_cut: problem biting extension type"
             in
             bite Emp xs efs >>= fun (rs, efs) ->
-            go ext_ty (hd, sp #< (Tm.ExtApp rs)) efs mode
+            (* TODO: this is ugly *)
+            let restriction =
+              List.map2 (fun x r -> let t = Tm.up (Tm.Ref {name = x; ushift = 0; twin = `Only}, Emp) in (Name.fresh (), `R (t, r))) (Bwd.to_list xs) rs
+            in
+            M.in_scopes restriction begin
+              normalize_ty ext_ty >>= fun ext_ty ->
+              go ext_ty (hd, sp #< (Tm.ExtApp rs)) efs mode
+            end
 
           | Tm.Sg (dom, _), E.Car :: efs ->
             go dom (hd, sp #< Tm.Car) efs mode

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -11,7 +11,7 @@
 %token <int> NUMERAL
 %token <string> ATOM
 %token <string option> HOLE_NAME
-%token LSQ RSQ LPR RPR LGL RGL
+%token LSQ RSQ LPR RPR LGL RGL LBR RBR
 %token COLON COLON_ANGLE COMMA DOT PIPE CARET
 %token EQUALS
 %token RIGHT_ARROW RRIGHT_ARROW
@@ -49,6 +49,8 @@ atomic_eterm:
     { E.Quo t }
   | a = HOLE_NAME;
     { E.Hole a }
+  | a = HOLE_NAME; LBR; e = eterm; RBR
+    { E.Guess e }
   | TYPE
     { E.Type }
   | LGL; es = separated_list(COMMA, eterm); RGL

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -49,7 +49,7 @@ atomic_eterm:
     { E.Quo t }
   | a = HOLE_NAME;
     { E.Hole a }
-  | a = HOLE_NAME; LBR; e = eterm; RBR
+  | HOLE_NAME; LBR; e = eterm; RBR
     { E.Guess e }
   | TYPE
     { E.Type }

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -16,7 +16,7 @@
 %token EQUALS
 %token RIGHT_ARROW RRIGHT_ARROW
 %token AST TIMES HASH AT BACKTICK IN WITH END
-%token S1 S1_REC NAT_REC LOOP BASE ZERO SUC POS NEGSUC INT INT_REC NAT BOOL UNIV LAM CONS CAR CDR TT FF IF COMP HCOM COM COE LET DEBUG CALL RESTRICT V VPROJ
+%token S1 S1_REC NAT_REC LOOP BASE ZERO SUC POS NEGSUC INT INT_REC NAT BOOL UNIV LAM CONS CAR CDR TT FF IF COMP HCOM COM COE LET DEBUG CALL RESTRICT V VPROJ VIN
 %token THEN ELSE
 %token IMPORT OPAQUE
 %token TYPE PRE KAN
@@ -279,6 +279,12 @@ tm:
     { fun env ->
       make_node $startpos $endpos @@
       Tm.V {r = r env; ty0 = ty0 env; ty1 = ty1 env; equiv = equiv env} }
+
+  | LPR; VIN; r = tm; tm0 = tm; tm1 = tm; RPR
+    { fun env ->
+      make_node $startpos $endpos @@
+      Tm.VIn {r = r env; tm0 = tm0 env; tm1 = tm1 env} }
+
 
   | LPR; RIGHT_ARROW; tele = tele; RPR
     { fun env ->

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -39,6 +39,7 @@ module Make (R : SOURCE) : LEXER = struct
       ("hcom", HCOM);
       ("comp", COMP);
       ("vproj", VPROJ);
+      ("vin", VIN);
       ("restrict", RESTRICT);
       ("if", IF);
       ("nat-rec", NAT_REC);
@@ -142,8 +143,12 @@ rule token = parse
     { Lwt.return EOF }
   | "?" atom_initial atom_subsequent*
     {
-      let input = lexeme lexbuf in
-      Lwt.return (Grammar.HOLE_NAME (Some input))
+      match String.split_on_char '?' @@ lexeme lexbuf with
+      | [] ->
+        Lwt.return @@ Grammar.HOLE_NAME None
+      | _ :: input ->
+        let name = String.concat "" input in
+        Lwt.return (Grammar.HOLE_NAME (Some name))
     }
   | "?"
     { Lwt.return (Grammar.HOLE_NAME None) }

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -95,6 +95,10 @@ rule token = parse
     { Lwt.return LSQ }
   | ']'
     { Lwt.return RSQ }
+  | '{'
+    { Lwt.return LBR }
+  | '}'
+    { Lwt.return RBR }
   | '#'
     { Lwt.return HASH }
   | '@'

--- a/src/frontend/Refiner.ml
+++ b/src/frontend/Refiner.ml
@@ -45,8 +45,13 @@ let guess_restricted ty sys tm =
         go sys
     in
     go sys >>
-    M.lift C.ask >>= fun psi ->
-    M.lift @@ U.push_guess psi ~ty0:rty ~ty1:ty tm
+    M.unify >>
+    M.lift @@ C.check ~ty:rty tm >>= fun b ->
+    if b then M.ret tm else
+      begin
+        M.lift @@ C.dump_state Format.err_formatter "damn" `All >>= fun _ ->
+        failwith "guess_restricted: type error"
+      end
 
 exception ChkMatch
 

--- a/test.red
+++ b/test.red
@@ -19,7 +19,7 @@ let not∘not/id/pt (x : bool) : Path _ (not∘not x) x =
   if x then λ _ → tt else λ _ → ff
 
 
-let not∘not/id : Path (_ → _) _ _ =
+let not∘not/id : Path (bool → bool) not∘not (id _) =
   λ i x →
     not∘not/id/pt x i
 
@@ -52,7 +52,7 @@ let hset/pi
   : hset ((x : A) → B x)
   =
   λ f g α β i j x →
-    hset/B _ _ _ (λ k → α k x) (λ k → β k x) i j
+    hset/B _ (f x) (g x) (λ k → α k x) (λ k → β k x) i j
 
 
 ; this is an example that doesn't work so well in redprl-style sequent calculus

--- a/univalence.red
+++ b/univalence.red
@@ -113,8 +113,7 @@ let LemSig
   =
   λ i →
     <P i,
-    ; bug in elaborator
-    `(@ (LemPropF A B B/prop P (cdr u) (cdr v)) i)>
+     LemPropF A B B/prop P (u.cdr) (v.cdr) i>
 
 
 let PropSig

--- a/univalence.red
+++ b/univalence.red
@@ -113,7 +113,7 @@ let LemSig
   =
   λ i →
     <P i,
-     LemPropF A B B/prop P (u.cdr) (v.cdr) i>
+     LemPropF _ _ B/prop P (u.cdr) (v.cdr) i>
 
 
 let PropSig

--- a/univalence.red
+++ b/univalence.red
@@ -47,18 +47,18 @@ let RetIsContr
 let IdEquiv (A : type) : Equiv A A =
   < λ a → a
   , λ a →
-    < <_, λ _ → a>
+    < <a, λ _ → a>
     , λ p i →
       let aux : Line A =
         λ j →
         comp 1 j a with
-        | i=0 ⇒ p.cdr
+        | i=0 ⇒ λ k → p.cdr k
         | i=1 ⇒ λ _ → a
         end
-      in <aux 0, λ j → aux j>
+      in
+      <aux 0, λ j → aux j>
     >
   >
-
 
 let PathToEquiv
   (A : type) (B : type) (P : Path^1 type A B)
@@ -88,7 +88,7 @@ let PropPi
   : IsProp ((a : A) → B a)
   =
   λ f g i a →
-    B/prop _ (f a) (g a) i
+    B/prop a (f a) (g a) i
 
 let PropSet
   (A : type) (A/prop : IsProp A)
@@ -111,7 +111,9 @@ let LemSig
   : Path ((a : A) × B a) u v
   =
   λ i →
-    <P i, LemPropF _ _ B/prop P (u.cdr) (v.cdr) i>
+    <P i,
+    ; bug in elaborator
+    `(@ (LemPropF A B B/prop P (cdr u) (cdr v)) i)>
 
 
 let PropSig

--- a/univalence.red
+++ b/univalence.red
@@ -1,4 +1,5 @@
 import path
+import connection
 
 ; the code in this file is adapted from yacctt and redprl
 
@@ -241,5 +242,49 @@ let univalence (A : type) : IsContr^1 ((B : type) × Equiv A B) =
     (SigPathToEquiv A)
     (UA/retract/sig A)
     (IsContrPath A)
+
+let IdEquiv/connection (B : type) : Equiv B B =
+  < λ b → b
+  , λ b →
+    < <b, λ _ → b>
+    , λ v i → <v.cdr i, λ j → connection/or B (v.car) b (v.cdr) i j>
+    >
+  >
+
+let univalence/alt (B : type) : IsContr^1 ((A : type) × Equiv A B) =
+  < <B, IdEquiv/connection B>
+  , λ w i →
+       let VB : type = `(V i (car w) B (cdr w)) in
+       let proj/B : VB → B = λ g → `(vproj i g (car w) B (cdr w)) in
+       < VB
+       , proj/B
+       , λ b →
+            let ctr/B : Line B =
+              λ j →
+                comp 1 j b with
+                | i=0 ⇒ λ k → w .cdr .cdr b .car .cdr k
+                | i=1 ⇒ λ _ → b
+                end
+            in
+            let ctr : Fiber VB B proj/B b =
+              < `(vin i (car (car ((cdr (cdr w)) b))) (@ ctr/B 0)), λ l → ctr/B l >
+            in
+            < ctr
+            , λ v j →
+                let filler : Line B =
+                  λ l →
+                    comp 1 l b with
+                    | i=0 ⇒ λ k → w .cdr .cdr b .cdr v j .cdr k
+                    | i=1 ⇒ λ k → connection/or B (v .car) b (v .cdr) j k
+                    | j=0 ⇒ λ k → v .cdr k
+                    | j=1 ⇒ λ k → ctr/B k
+                    end
+                in
+                < `(vin i (car (@ ((cdr ((cdr (cdr w)) b)) v) j)) (@ filler 0))
+                , λ j → filler j
+                >
+            >
+       >
+  >
 
 debug


### PR DESCRIPTION
This PR includes the eta law for V-types, but it also includes some a more immortal version of the elaborator that lets the user control intermediate states where boundaries don't match *yet*. But it also uncovers some bugs in other parts of the code.