### PR TITLE
Fixes

### DIFF
--- a/omega1s1-wip.red
+++ b/omega1s1-wip.red
@@ -43,6 +43,11 @@ let nat/25 : nat =
 let int/50 : int =
   pos (plus nat/25 nat/25)
 
-let winding-loop-testing1 : Path int int/50 (winding (loopn int/50)) =
+let int/5 : int = pos nat/five
+
+let winding-test/5 : Path int int/5 (winding (loopn int/5)) =
+  λ _ → int/5
+
+let winding-test/50 : Path int int/50 (winding (loopn int/50)) =
   λ _ → int/50
 

--- a/omega1s1-wip.red
+++ b/omega1s1-wip.red
@@ -34,7 +34,7 @@ let two : int = pos (suc (suc zero))
 let winding-loop-testing0 : Path int two (winding (loopn two)) =
   λ _ → two
 
-let five : int = pos (suc (suc (suc (suc zero))))
+let five : int = pos (suc (suc (suc (suc (suc zero)))))
 
 let winding-loop-testing1 : Path int five (winding (loopn five)) =
   λ _ → five

--- a/omega1s1-wip.red
+++ b/omega1s1-wip.red
@@ -37,9 +37,12 @@ let winding-loop-testing0 : Path int two (winding (loopn two)) =
 let nat/five : nat =
   suc (suc (suc (suc (suc zero))))
 
-let int/25 : int =
-  pos (plus nat/five (plus nat/five (plus nat/five (plus nat/five nat/five))))
+let nat/25 : nat =
+  plus nat/five (plus nat/five (plus nat/five (plus nat/five nat/five)))
 
-let winding-loop-testing1 : Path int int/25 (winding (loopn int/25)) =
-  λ _ → int/25
+let int/50 : int =
+  pos (plus nat/25 nat/25)
+
+let winding-loop-testing1 : Path int int/50 (winding (loopn int/50)) =
+  λ _ → int/50
 

--- a/omega1s1-wip.red
+++ b/omega1s1-wip.red
@@ -34,8 +34,12 @@ let two : int = pos (suc (suc zero))
 let winding-loop-testing0 : Path int two (winding (loopn two)) =
   λ _ → two
 
-let five : int = pos (suc (suc (suc (suc (suc zero)))))
+let nat/five : nat =
+  suc (suc (suc (suc (suc zero))))
 
-let winding-loop-testing1 : Path int five (winding (loopn five)) =
-  λ _ → five
+let int/25 : int =
+  pos (plus nat/five (plus nat/five (plus nat/five (plus nat/five nat/five))))
+
+let winding-loop-testing1 : Path int int/25 (winding (loopn int/25)) =
+  λ _ → int/25
 

--- a/src/core/Cx.ml
+++ b/src/core/Cx.ml
@@ -109,7 +109,7 @@ let ext_ty cx ~nm ty =
   ext cx ~nm ty []
 
 let def cx ~nm ~ty ~el =
-  let face = Face.True (`Dim0, `Dim1, el) in
+  let face = Face.True (`Dim0, `Dim1, lazy el) in
   fst @@ ext cx ~nm ty [face]
 
 let ext_dim cx ~nm =

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -54,9 +54,9 @@ and pp_con fmt : con -> unit =
   | Cons (v0, v1) ->
     Format.fprintf fmt "@[<1>(pair@ %a %a)@]" pp_value v0 pp_value v1
   | V info ->
-    Format.fprintf fmt "@[<1>(V@ %a@ %a@ %a@ %a)]" Name.pp info.x pp_value info.ty0 pp_value info.ty1 pp_value info.equiv
+    Format.fprintf fmt "@[<1>(V@ %a@ %a@ %a@ %a)@]" Name.pp info.x pp_value info.ty0 pp_value info.ty1 pp_value info.equiv
   | VIn info ->
-    Format.fprintf fmt "@[<1>(Vin@ %a@ %a@ %a)]" Name.pp info.x pp_value info.el0 pp_value info.el1
+    Format.fprintf fmt "@[<1>(Vin@ %a@ %a@ %a)@]" Name.pp info.x pp_value info.el0 pp_value info.el1
   | Coe info ->
     let r, r' = Dir.unleash info.dir in
     Format.fprintf fmt "@[<1>(coe %a %a@ %a@ %a)@]" I.pp r I.pp r' pp_abs info.abs pp_value info.el
@@ -67,8 +67,9 @@ and pp_con fmt : con -> unit =
     Format.fprintf fmt "<ghcom>"
   | FHCom _ ->
     Format.fprintf fmt "<fhcom>"
-  | Box _ ->
-    Format.fprintf fmt "<box>"
+  | Box info ->
+    let r, r' = Dir.unleash info.dir in
+    Format.fprintf fmt "@[<1>(box %a %a@ %a@ %a)@]" I.pp r I.pp r' pp_value info.cap pp_val_sys info.sys
   | LblTy {lbl; args; ty} ->
     begin
       match args with

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -32,7 +32,7 @@ and pp_env fmt =
 and pp_con fmt : con -> unit =
   function
   | Up up ->
-    Format.fprintf fmt "%a" pp_neu up.neu
+    Format.fprintf fmt "@[<hv1>(up@ %a@ %a@ [%a])@]" pp_value up.ty pp_neu up.neu pp_val_sys up.sys
   | Lam clo ->
     Format.fprintf fmt "@[<1>(λ@ %a)@]" pp_clo clo
   | ExtLam abs ->
@@ -207,8 +207,12 @@ and pp_neu fmt neu =
   | Meta {name; _} ->
     Name.pp fmt name
 
-  | Elim _ ->
-    Format.fprintf fmt "<elim>"
+  | Elim info ->
+    Format.fprintf fmt "@[<hv1>(%a.elim@ %a@ %a@ %a)@]"
+      Desc.pp_data_label info.dlbl
+      pp_clo info.mot
+      pp_neu info.neu
+      pp_elim_clauses info.clauses
 
   | Cap _ ->
     Format.fprintf fmt "<cap>"
@@ -234,6 +238,12 @@ and pp_neu fmt neu =
   | Open _ ->
     Format.fprintf fmt "<open>"
 
+and pp_elim_clauses fmt clauses =
+  let pp_sep fmt () = Format.fprintf fmt "@ " in
+  Format.pp_print_list ~pp_sep pp_elim_clause fmt clauses
+
+and pp_elim_clause fmt (clbl, nclo) =
+  Format.fprintf fmt "@[<hv1>[%a@ %a]@]" Uuseg_string.pp_utf_8 clbl pp_nclo nclo
 
 and pp_nf fmt nf =
   pp_value fmt nf.el

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -139,12 +139,12 @@ and pp_val_face : type x. _ -> (x, value) face -> unit =
   fun fmt ->
     function
     | Face.True (r0, r1, v) ->
-      Format.fprintf fmt "@[<1>[!%a=%a@ %a]@]" I.pp r0 I.pp r1 pp_value v
+      Format.fprintf fmt "@[<1>[!%a=%a@ %a]@]" I.pp r0 I.pp r1 pp_value (Lazy.force v)
     | Face.False (r0, r1) ->
       Format.fprintf fmt "@[<1>[%a/=%a]@]" I.pp r0 I.pp r1
     | Face.Indet (p, v) ->
       let r0, r1 = Eq.unleash p in
-      Format.fprintf fmt "@[<1>[?%a=%a %a]@]" I.pp r0 I.pp r1 pp_value v
+      Format.fprintf fmt "@[<1>[?%a=%a %a]@]" I.pp r0 I.pp r1 pp_value (Lazy.force v)
 
 and pp_comp_sys : type x. Format.formatter -> (x, abs) face list -> unit =
   fun fmt ->
@@ -155,12 +155,12 @@ and pp_comp_face : type x. _ -> (x, abs) face -> unit =
   fun fmt ->
     function
     | Face.True (r0, r1, v) ->
-      Format.fprintf fmt "@[<1>[!%a=%a@ %a]@]" I.pp r0 I.pp r1 pp_abs v
+      Format.fprintf fmt "@[<1>[!%a=%a@ %a]@]" I.pp r0 I.pp r1 pp_abs (Lazy.force v)
     | Face.False (r0, r1) ->
       Format.fprintf fmt "@[<1>[%a/=%a]@]" I.pp r0 I.pp r1
     | Face.Indet (p, v) ->
       let r0, r1 = Eq.unleash p in
-      Format.fprintf fmt "@[<1>[?%a=%a %a]@]" I.pp r0 I.pp r1 pp_abs v
+      Format.fprintf fmt "@[<1>[?%a=%a %a]@]" I.pp r0 I.pp r1 pp_abs (Lazy.force v)
 
 and pp_clo fmt (Clo clo) =
   let Tm.B (_, tm) = clo.bnd in
@@ -283,7 +283,7 @@ module AbsFace = Face.M (Abs)
 let force_abs_face face =
   match face with
   | Face.True (_, _, abs) ->
-    raise @@ ProjAbs abs
+    raise @@ ProjAbs (Lazy.force abs)
   | Face.False _ -> None
   | Face.Indet (xi, abs) ->
     Some (Face.Indet (xi, abs))
@@ -291,7 +291,7 @@ let force_abs_face face =
 let force_val_face (face : val_face) =
   match face with
   | Face.True (_, _, v) ->
-    raise @@ ProjVal v
+    raise @@ ProjVal (Lazy.force v)
   | Face.False _ -> None
   | Face.Indet (xi, v) ->
     Some (Face.Indet (xi, v))
@@ -330,7 +330,7 @@ struct
     | face :: sys ->
       match AbsFace.act phi face with
       | Face.True (_, _, abs) ->
-        raise @@ Proj abs
+        raise @@ Proj (Lazy.force abs)
       | Face.False _ ->
         act_aux phi sys
       | Face.Indet (p, t) ->
@@ -374,7 +374,7 @@ struct
     | face :: sys ->
       match ValFace.act phi face with
       | Face.True (_, _, value) ->
-        raise @@ Proj value
+        raise @@ Proj (Lazy.force value)
       | Face.False _ ->
         act_aux phi sys
       | Face.Indet (p, t) ->

--- a/src/core/Face.mli
+++ b/src/core/Face.mli
@@ -1,7 +1,7 @@
 type (_, 'a) face =
   | False : I.t * I.t -> ([`Any], 'a) face
-  | True : I.t * I.t * 'a -> ([`Any], 'a) face
-  | Indet : Eq.t * 'a -> ('x, 'a) face
+  | True : I.t * I.t * 'a lazy_t -> ([`Any], 'a) face
+  | Indet : Eq.t * 'a lazy_t -> ('x, 'a) face
 
 val map : (I.t -> I.t -> 'a -> 'b) -> ('x, 'a) face -> ('x, 'b) face
 

--- a/src/core/IAbs.ml
+++ b/src/core/IAbs.ml
@@ -19,12 +19,16 @@ sig
 
   include Sort.S with type 'a m = 'a with type t = el abs
 
+  val unsafe_map : (el -> el) -> t -> t
+
+  val unsafe_bind : atom bwd -> el -> t
   val bind : atom bwd -> el -> t
   val unleash : t -> atom bwd * el
   val inst : t -> I.t bwd -> el
 
   val len : t -> int
 
+  val unsafe_bind1 : atom -> el -> t
   val bind1 : atom -> el -> t
   val unleash1 : t -> atom * el
   val inst1 : t -> I.t -> el
@@ -37,6 +41,9 @@ struct
   type el = X.t
   type 'a m = 'a
   type t = X.t abs
+
+  let unsafe_map f abs =
+    {abs with node = f abs.node}
 
   let len abs = Bwd.length abs.atoms
 
@@ -66,8 +73,21 @@ struct
     in
     go [] atoms I.idn
 
+  let unsafe_bind atoms node =
+    let rec go ys atoms =
+      match atoms with
+      | Emp ->
+        {atoms = Bwd.from_list ys; node = node}
+      | Snoc (atoms, x) ->
+        go (x :: ys) atoms
+    in
+    go [] atoms
+
   let bind1 x el =
     bind (Emp #< x) el
+
+  let unsafe_bind1 x el =
+    unsafe_bind (Emp #< x) el
 
   let unleash1 abs =
     let xs, el = unleash abs in

--- a/src/core/IAbs.ml
+++ b/src/core/IAbs.ml
@@ -103,7 +103,7 @@ struct
 
   let make1 gen =
     let x = Name.fresh () in
-    bind1 x (gen x)
+    unsafe_bind1 x (gen x)
 
   let act phi abs =
     let xs, node = unleash abs in

--- a/src/core/IAbs.mli
+++ b/src/core/IAbs.mli
@@ -12,11 +12,16 @@ sig
 
   include Sort.S with type 'a m = 'a with type t = el abs
 
+  val unsafe_map : (el -> el) -> t -> t
+
+  val unsafe_bind : atom bwd -> el -> t
   val bind : atom bwd -> el -> t
   val unleash : t -> atom bwd * el
   val inst : t -> I.t bwd -> el
 
   val len : t -> int
+
+  val unsafe_bind1 : atom -> el -> t
 
   val bind1 : atom -> el -> t
   val unleash1 : t -> atom * el

--- a/src/core/Tm.mli
+++ b/src/core/Tm.mli
@@ -36,7 +36,7 @@ val bindn : Name.t bwd -> tm -> tm nbnd
 val unbind : tm bnd -> Name.t * tm
 val unbindn : tm nbnd -> Name.t bwd * tm
 val unbind_ext : (tm * (tm, tm) system) nbnd -> Name.t bwd * tm * (tm, tm) system
-val unbind_ext_with : Name.t list -> (tm * (tm, tm) system) nbnd -> tm * (tm, tm) system
+val unbind_ext_with : tm cmd list -> (tm * (tm, tm) system) nbnd -> tm * (tm, tm) system
 val bind_ext : Name.t bwd -> tm -> (tm, tm) system -> (tm * (tm, tm) system) nbnd
 
 val unbind_with : tm cmd -> tm bnd -> tm

--- a/src/core/TmData.ml
+++ b/src/core/TmData.ml
@@ -56,6 +56,7 @@ and 'a head =
   | Var of {name : Name.t; twin : twin; ushift : int}
   | Ix of int * twin
   | Down of {ty : 'a; tm : 'a}
+  | DownX of 'a
   | DFix of {r : 'a; ty : 'a; bdy : 'a bnd}
   | Coe of {r : 'a; r' : 'a; ty : 'a bnd; tm : 'a}
   | HCom of {r : 'a; r' : 'a; ty : 'a; cap : 'a; sys : ('a, 'a bnd) system}

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -61,6 +61,8 @@ and check_dim_cmd cx =
       | Tm.Var _ ->
         (* TODO: lookup in global context, make sure it is a dimension *)
         ()
+      | Tm.DownX r ->
+        check_dim cx r
       | _ -> failwith ""
     end
   | _ ->
@@ -748,6 +750,9 @@ and infer_head cx =
     let ty = check_eval_ty cx info.ty in
     check cx ty info.tm;
     ty
+
+  | T.DownX _ ->
+    failwith "infer_head/DownX"
 
   | T.DFix info ->
     check_dim cx info.r;

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -258,7 +258,7 @@ let rec check cx ty tm =
         begin
           match I.compare r'0 r0, I.compare r'1 r1 with
           | `Same, `Same ->
-            check cx ty tm
+            check cx (Lazy.force ty) tm
           | _ ->
             failwith "co-restriction mismatch"
         end
@@ -270,7 +270,7 @@ let rec check cx ty tm =
             begin
               try
                 let cx', phi = Cx.restrict cx r'0 r'1 in
-                check cx' (Domain.Value.act phi ty) tm
+                check cx' (Domain.Value.act phi @@ Lazy.force ty) tm
               with
               | I.Inconsistent -> ()
             end
@@ -375,7 +375,7 @@ and check_boundary cx ty sys tm =
 and check_boundary_face cx ty face tm =
   match face with
   | Face.True (_, _, el) ->
-    Cx.check_eq cx ~ty el @@
+    Cx.check_eq cx ~ty (Lazy.force el) @@
     Cx.eval cx tm
 
   | Face.False _ ->
@@ -385,7 +385,7 @@ and check_boundary_face cx ty face tm =
     let r, r' = Eq.unleash p in
     try
       let cx', phi = Cx.restrict cx r r' in
-      Cx.check_eq cx' ~ty:(D.Value.act phi ty) el @@
+      Cx.check_eq cx' ~ty:(D.Value.act phi ty) (Lazy.force el) @@
       Cx.eval cx' tm
     with
     | I.Inconsistent ->
@@ -649,7 +649,7 @@ and infer_spine cx hd =
       begin
         match V.unleash_corestriction_ty ih.ty with
         | Face.True (_, _, ty) ->
-          D.{el = Cx.eval_frame cx ih.el frm; ty}
+          D.{el = Cx.eval_frame cx ih.el frm; ty = Lazy.force ty}
         | _ -> failwith "Cannot force co-restriction when it is not true!"
       end
 

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -528,22 +528,8 @@ struct
           step @@ corestriction_force v
       end
 
-    | Lvl _ ->
+    | (Lvl _ | Var _ | Meta _) ->
       ret con
-
-    | Var {name; ushift; twin} ->
-      let tty, tsys = Sig.lookup name twin in
-      let rho' = {Env.emp with global = phi} in
-      let vsys = eval_tm_sys rho' @@ Tm.map_tm_sys (Tm.shift_univ ushift) tsys in
-      let vty = eval rho' @@ Tm.shift_univ ushift tty in
-      step @@ reflect vty (Var {name; ushift; twin}) vsys
-
-    | Meta {name; ushift} ->
-      let tty, tsys = Sig.lookup name `Only in
-      let rho' = {Env.emp with global = phi} in
-      let vsys = eval_tm_sys rho' @@ Tm.map_tm_sys (Tm.shift_univ ushift) tsys in
-      let vty = eval rho' @@ Tm.shift_univ ushift tty in
-      step @@ reflect vty (Meta {name; ushift}) vsys
 
     | Prev (tick, neu) ->
       begin

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -2366,7 +2366,7 @@ struct
       let abs =
         let r, _ = Dir.unleash info.dir in
         let dom, cod = unleash_sg info.ty in
-        let z = Name.fresh () in
+        Abs.make1 @@ fun z ->
         let msys =
           let face =
             Face.map @@ fun _ _ ->
@@ -2381,7 +2381,7 @@ struct
             (car info.cap)
             msys
         in
-        Abs.unsafe_bind1 z @@ inst_clo cod hcom
+        inst_clo cod hcom
       in
       let cap = cdr info.cap in
       let sys =

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -1832,7 +1832,7 @@ struct
     let Tm.NB (nms, (tm, sys)) = bnd in
     let xs = Bwd.map Name.named nms in
     let rho = Env.push_many (List.rev @@ Bwd.to_list @@ Bwd.map (fun x -> `Dim (`Atom x)) xs) rho in
-    ExtAbs.bind xs (eval rho tm, eval_tm_sys rho sys)
+    ExtAbs.unsafe_bind xs (eval rho tm, eval_tm_sys rho sys)
 
   and unleash_data v =
     match unleash v with

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -757,7 +757,7 @@ struct
     | (_, spec) :: const_specs, arg :: args ->
       let vty = eval env spec in
       let r, r' = Dir.unleash dir in
-      let coe_hd s = make_coe (Dir.make r s) (Abs.bind1 x vty) arg in
+      let coe_hd s = make_coe (Dir.make r s) (Abs.unsafe_bind1 x vty) arg in
       let coe_tl =
         let coe_hd_x = coe_hd @@ `Atom x in
         rigid_multi_coe (Env.push (`Val coe_hd_x) env) dir (x, const_specs) args

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -1809,13 +1809,13 @@ struct
     let Tm.B (_, tm) = bnd in
     let x = Name.fresh () in
     let rho = Env.push (`Dim (`Atom x)) rho in
-    Abs.bind1 x @@ eval rho tm
+    Abs.unsafe_bind1 x @@ eval rho tm
 
   and eval_nbnd rho bnd =
     let Tm.NB (nms, tm) = bnd in
     let xs = Bwd.map Name.named nms in
     let rho = Env.push_many (List.rev @@ Bwd.to_list @@ Bwd.map (fun x -> `Dim (`Atom x)) xs) rho in
-    Abs.bind xs @@ eval rho tm
+    Abs.unsafe_bind xs @@ eval rho tm
 
   and eval_ext_bnd rho bnd =
     let Tm.NB (nms, (tm, sys)) = bnd in

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -1160,14 +1160,14 @@ struct
 
       let peel_sys k sys = List.map (peel_face k) sys in
 
-      let rec make_args i acc args ps atys =
-        match args, ps, atys with
-        | el :: args, _ :: ps, _ ->
-          make_args (i + 1) (acc #< el) args ps atys
-        | el :: args, [], (_, Desc.Self) :: atys ->
+      let rec make_args i acc cvs rvs const_specs rec_specs =
+        match cvs, rvs, const_specs, rec_specs with
+        | el :: cvs, _, _ :: const_specs, _ ->
+          make_args (i + 1) (acc #< el) cvs rvs const_specs rec_specs
+        | [], el :: rvs, [], (_, Desc.Self) :: rec_specs ->
           let hcom = rigid_hcom dir ty el (peel_sys i sys) in
-          make_args (i + 1) (acc #< hcom) args ps atys
-        | [], [], [] ->
+          make_args (i + 1) (acc #< hcom) cvs rvs const_specs rec_specs
+        | [], [], [], []->
           Bwd.to_list acc
         | _ ->
           failwith "rigid_hcom_strict_data"
@@ -1176,8 +1176,7 @@ struct
       let desc = Sig.lookup_datatype dlbl in
       let constr = Desc.lookup_constr info.clbl desc in
 
-      (* TODO: clean this up! this was written before I split the args into two lists *)
-      let args' = make_args 0 Emp (info.const_args @ info.rec_args) constr.const_specs constr.rec_specs in
+      let args' = make_args 0 Emp info.const_args info.rec_args constr.const_specs constr.rec_specs in
       let const_args, rec_args = ListUtil.split (List.length constr.const_specs) args' in
 
       make @@ Intro {dlbl; clbl = info.clbl; const_args; rec_args; rs = []; sys = []}

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -1818,9 +1818,9 @@ struct
 
   and eval_bnd rho bnd =
     let Tm.B (_, tm) = bnd in
-    let x = Name.fresh () in
+    Abs.make1 @@ fun x ->
     let rho = Env.push (`Dim (`Atom x)) rho in
-    Abs.unsafe_bind1 x @@ eval rho tm
+    eval rho tm
 
   and eval_nbnd rho bnd =
     let Tm.NB (nms, tm) = bnd in
@@ -2303,7 +2303,7 @@ struct
 
     | Up info ->
       let dom, _ = unleash_sg info.ty in
-      let car_sys = List.map (Face.map (fun _ _ a -> car a)) info.sys in
+      let car_sys = List.map (Face.map (fun _ _ -> car)) info.sys in
       make @@ Up {ty = dom; neu = Car info.neu; sys = car_sys}
 
     | Coe info ->
@@ -2343,7 +2343,7 @@ struct
 
     | Up info ->
       let _, cod = unleash_sg info.ty in
-      let cdr_sys = List.map (Face.map (fun _ _ a -> cdr a)) info.sys in
+      let cdr_sys = List.map (Face.map (fun _ _ -> cdr)) info.sys in
       let cod_car = inst_clo cod @@ car v in
       make @@ Up {ty = cod_car; neu = Cdr info.neu; sys = cdr_sys}
 
@@ -2396,9 +2396,9 @@ struct
 
     | GHCom info ->
       let abs =
+        Abs.make1 @@ fun z ->
         let r, _ = Dir.unleash info.dir in
         let dom, cod = unleash_sg info.ty in
-        let z = Name.fresh () in
         let msys =
           let face =
             Face.map @@ fun _ _ ->
@@ -2413,7 +2413,7 @@ struct
             (car info.cap)
             msys
         in
-        Abs.unsafe_bind1 z @@ inst_clo cod hcom
+        inst_clo cod hcom
       in
       let cap = cdr info.cap in
       let sys =

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -1154,9 +1154,8 @@ struct
       in
 
       let peel_face k =
-        Face.map @@ fun _ _ abs ->
-        let x, elx = Abs.unleash1 abs in
-        Abs.bind1 x @@ peel_arg k elx
+        Face.map @@ fun _ _ ->
+        Abs.unsafe_map (peel_arg k)
       in
 
       let peel_sys k sys = List.map (peel_face k) sys in
@@ -2324,9 +2323,8 @@ struct
       let dom, _ = unleash_sg info.ty in
       let cap = car info.cap in
       let face =
-        Face.map @@ fun _ _ abs ->
-        let y, v = Abs.unleash1 abs in
-        Abs.bind1 y @@ car v
+        Face.map @@ fun _ _ ->
+        Abs.unsafe_map car
       in
       let sys = List.map face info.sys in
       rigid_hcom info.dir dom cap sys
@@ -2335,9 +2333,8 @@ struct
       let dom, _ = unleash_sg info.ty in
       let cap = car info.cap in
       let face =
-        Face.map @@ fun _ _ abs ->
-        let y, v = Abs.unleash1 abs in
-        Abs.bind1 y @@ car v
+        Face.map @@ fun _ _ ->
+        Abs.unsafe_map car
       in
       let sys = List.map face info.sys in
       rigid_ghcom info.dir dom cap sys

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -2379,9 +2379,8 @@ struct
         let z = Name.fresh () in
         let msys =
           let face =
-            Face.map @@ fun _ _ absi ->
-            let yi, vi = Abs.unleash absi in
-            Abs.bind yi @@ car vi
+            Face.map @@ fun _ _ ->
+            Abs.unsafe_map car
           in
           `Ok (List.map face info.sys)
         in
@@ -2392,14 +2391,13 @@ struct
             (car info.cap)
             msys
         in
-        Abs.bind1 z @@ inst_clo cod hcom
+        Abs.unsafe_bind1 z @@ inst_clo cod hcom
       in
       let cap = cdr info.cap in
       let sys =
         let face =
-          Face.map @@ fun _ _ absi ->
-          let yi, vi = Abs.unleash absi in
-          Abs.bind yi @@ cdr vi
+          Face.map @@ fun _ _ ->
+          Abs.unsafe_map cdr
         in
         List.map face info.sys
       in
@@ -2412,9 +2410,8 @@ struct
         let z = Name.fresh () in
         let msys =
           let face =
-            Face.map @@ fun _ _ absi ->
-            let yi, vi = Abs.unleash absi in
-            Abs.bind yi @@ car vi
+            Face.map @@ fun _ _ ->
+            Abs.unsafe_map car
           in
           `Ok (List.map face info.sys)
         in
@@ -2425,14 +2422,13 @@ struct
             (car info.cap)
             msys
         in
-        Abs.bind1 z @@ inst_clo cod hcom
+        Abs.unsafe_bind1 z @@ inst_clo cod hcom
       in
       let cap = cdr info.cap in
       let sys =
         let face =
-          Face.map @@ fun _ _ absi ->
-          let yi, vi = Abs.unleash absi in
-          Abs.bind yi @@ cdr vi
+          Face.map @@ fun _ _ ->
+          Abs.unsafe_map cdr
         in
         List.map face info.sys
       in

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -1255,7 +1255,7 @@ struct
 
       (* This serves as `O` and the diagonal face in [F]
        * for the coherence conditions in `fhcom.sys` and `s=s'`. *)
-      let hcom_template phi y_dest ~ty =
+      let hcom_template phi y_dest ty =
         make_hcom
           (Dir.make (I.act phi r) y_dest)
           ty
@@ -1279,20 +1279,20 @@ struct
             let phi = I.equate si s'i in
             Abs.make1 @@ fun y ->
             (* this is not the most efficient code, but maybe we can afford this? *)
-            cap_aux phi @@ hcom_template phi (`Atom y) ~ty:(Value.act phi (Abs.inst1 abs s'))
+            cap_aux phi @@ hcom_template phi (`Atom y) (Value.act phi (Abs.inst1 abs s'))
           in
           List.map face fhcom.sys
         in
         let diag =
           AbsFace.make_from_dir I.idn fhcom.dir @@ fun phi ->
-          Abs.make1 @@ fun y -> hcom_template phi (`Atom y) ~ty:(Value.act phi fhcom.cap)
+          Abs.make1 @@ fun y -> hcom_template phi (`Atom y) (Value.act phi fhcom.cap)
         in
         Option.filter_map force_abs_face [diag] @ (ri_faces @ si_faces)
       in
       let boundary =
         Face.map @@ fun si s'i abs ->
         let phi = I.equate si s'i in
-        hcom_template phi (I.act phi r') ~ty:(Value.act phi (Abs.inst1 abs s'))
+        hcom_template phi (I.act phi r') (Value.act phi (Abs.inst1 abs s'))
       in
       rigid_box fhcom.dir new_cap @@
       List.map boundary fhcom.sys

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -182,7 +182,7 @@ struct
   let make_closure rho bnd =
     Clo {bnd; rho}
 
-  let eval_dim rho tm =
+  let rec eval_dim rho tm =
     match Tm.unleash tm with
     | Tm.Dim0 ->
       `Dim0
@@ -205,6 +205,9 @@ struct
 
         | Tm.Meta meta ->
           I.act rho.global @@ Sig.global_dim meta.name
+
+        | Tm.DownX r ->
+          eval_dim rho r
 
         | _ ->
           let err = ExpectedDimensionTerm tm in
@@ -1661,6 +1664,9 @@ struct
     function
     | Tm.Down info ->
       eval rho info.tm
+
+    | Tm.DownX _ ->
+      failwith "eval_head/DownX"
 
     | Tm.DFix info ->
       let r = eval_dim rho info.r in

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,6 +1,6 @@
 (library
  (name RedTT_Core)
  (flags
-  (:standard -w -32))
+  (:standard -w -32-37))
  (public_name redtt_core)
  (libraries redbasis uuseg uuseg.string uutf))

--- a/src/frontend/Refiner.ml
+++ b/src/frontend/Refiner.ml
@@ -188,7 +188,7 @@ let rec tac_lambda names tac ty =
           | _ -> failwith "Elab: incorrect number of binders when refining extension type"
         in
         let xs, tac' = bite nms Emp names in
-        let ty, sys = Tm.unbind_ext_with (Bwd.to_list xs) ebnd in
+        let ty, sys = Tm.unbind_ext_with (Bwd.to_list @@ Bwd.map (fun x -> Tm.var x) xs) ebnd in
         let rty = Tm.make @@ Tm.Rst {ty; sys} in
         let ps = List.map (fun x -> (x, `I)) @@ Bwd.to_list xs in
         M.in_scopes ps begin

--- a/src/frontend/Unify.ml
+++ b/src/frontend/Unify.ml
@@ -611,7 +611,7 @@ let rec subtype ty0 ty1 =
     | Tm.Ext ebnd0, Tm.Ext ebnd1 ->
       let xs, ty0, sys0 = Tm.unbind_ext ebnd0 in
       let xs_fwd = Bwd.to_list xs in
-      let ty1, sys1 = Tm.unbind_ext_with xs_fwd ebnd1 in
+      let ty1, sys1 = Tm.unbind_ext_with (List.map Tm.var xs_fwd) ebnd1 in
       let ps = List.map (fun x -> (x, `I)) xs_fwd in
       let rec go sys0 sys1 =
         match sys0, sys1 with


### PR DESCRIPTION
This partially fixes what turned out to be a very bad idea. It's hard to explain, but let me try. The global environment is fixed for an instance of the `Val.M` functor, but values may persist from one instance of `Val.M` to another; so what may appear to be a whnf may no longer be a whnf.

I tried to work around this by forcing `act` to re-require the global environment and patch up the value, but this leads to inconsistent & incorrect behavior which is masked by other crap. The right thing to do is maintain the invariant that an element of the semantic domain is manipulated using the version of `Val.M` which it came from. Ultimately we should probably use abstract types to enforce this, but I am worried that we would hamstring our ability to refactor if we introduced that right away. Especially considering that I'd like to blow away all that architecture.


---------

It also fixes a subtle bug in `hcom` of `fhcom`.


-----------

***This also fixes the performance problems from #216. The 5th winding number computes in `.012s`, and the 50th in less than a second.***