### PR TITLE
HITs with declared level and kind

### DIFF
--- a/src/core/Desc.ml
+++ b/src/core/Desc.ml
@@ -1,4 +1,4 @@
-type 'a arg_ty =
+type 'a rec_spec =
   | Self
 
 
@@ -23,7 +23,7 @@ end
 
 type ('a, 'b) constr =
   {const_specs : (string * 'a) list;
-   rec_specs : (string * 'a arg_ty) list;
+   rec_specs : (string * 'a rec_spec) list;
    dim_specs : string list;
    boundary : ('a, 'b) Boundary.sys}
 

--- a/src/core/Desc.ml
+++ b/src/core/Desc.ml
@@ -30,7 +30,9 @@ type ('a, 'b) constr =
 
 (** A datatype description is just a list of named constructors. *)
 type ('a, 'b) desc =
-  {constrs : (con_label * ('a, 'b) constr) list}
+  {kind : Kind.t;
+   lvl : Lvl.t;
+   constrs : (con_label * ('a, 'b) constr) list}
 
 exception ConstructorNotFound of con_label
 

--- a/src/core/Desc.mli
+++ b/src/core/Desc.mli
@@ -39,7 +39,9 @@ type ('a, 'b) constr =
 
 (** A datatype description is just a list of named constructors. *)
 type ('a, 'b) desc =
-  {constrs : (con_label * ('a, 'b) constr) list}
+  {kind : Kind.t;
+   lvl : Lvl.t;
+   constrs : (con_label * ('a, 'b) constr) list}
 
 exception ConstructorNotFound of con_label
 val lookup_constr : con_label -> ('a, 'b) desc -> ('a, 'b) constr

--- a/src/core/Desc.mli
+++ b/src/core/Desc.mli
@@ -1,6 +1,6 @@
 (** Recursive argument types; currently this includes only [Self]; in the future, this will be extended with an indexed
     version of [Self], as well a formal function type. *)
-type 'a arg_ty =
+type 'a rec_spec =
   | Self
 
 (* TODO: abstract *)
@@ -32,7 +32,7 @@ end
     arguments. TODO: rename [args] to [rec_args]. *)
 type ('a, 'b) constr =
   {const_specs : (string * 'a) list;
-   rec_specs : (string * 'a arg_ty) list;
+   rec_specs : (string * 'a rec_spec) list;
    dim_specs : string list;
    boundary : ('a, 'b) Boundary.sys}
 

--- a/src/core/Kind.ml
+++ b/src/core/Kind.ml
@@ -1,18 +1,18 @@
-type t = Reg | Kan | Pre
+type t = [`Reg | `Kan | `Pre]
 
 let pp fmt =
   function
-  | Reg ->
+  | `Reg ->
     Format.fprintf fmt "reg"
-  | Kan ->
+  | `Kan ->
     Format.fprintf fmt "kan"
-  | Pre ->
+  | `Pre ->
     Format.fprintf fmt "pre"
 
 let lte k0 k1 =
   match k0, k1 with
-  | Reg, _ -> true
-  | _, Reg -> false
-  | Kan, _ -> true
-  | _, Kan -> false
-  | Pre, Pre -> true
+  | `Reg, _ -> true
+  | _, `Reg -> false
+  | `Kan, _ -> true
+  | _, `Kan -> false
+  | `Pre, `Pre -> true

--- a/src/core/Lvl.ml
+++ b/src/core/Lvl.ml
@@ -1,29 +1,24 @@
-type t = Omega | Const of int
+type t = [`Omega | `Const of int]
 
 let greater l0 l1 =
   match l0, l1 with
-  | Omega, _ -> true
+  | `Omega, _ -> true
   (* The above is wrong, but it lets us work around some annoying complications with defining large eliminations;
      it's harmless, because the user is not able to type in the Omega universe. *)
 
-  | Const i0, Const i1 -> i0 > i1
+  | `Const i0, `Const i1 -> i0 > i1
   | _ -> false
 
 let lte l0 l1 = l0 = l1 || greater l1 l0
 
 let shift k =
   function
-  | Omega -> Omega
-  | Const i -> Const (i + k)
-
-let to_string l =
-  match l with
-  | Omega -> "omega"
-  | Const i -> string_of_int i
+  | `Omega -> `Omega
+  | `Const i -> `Const (i + k)
 
 let pp fmt l =
   match l with
-  | Omega ->
-    Format.fprintf fmt "omega"
-  | Const i ->
+  | `Omega ->
+    Uuseg_string.pp_utf_8 fmt "ω"
+  | `Const i ->
     Format.fprintf fmt "%i" i

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -80,7 +80,7 @@ sig
     : env
     -> Desc.data_label
     -> (Tm.tm, Tm.tm Desc.Boundary.term) Desc.desc
-    -> Tm.tm Desc.arg_ty
+    -> Tm.tm Desc.rec_spec
     -> value
     -> value
     -> unit

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -282,7 +282,7 @@ struct
         Tm.make @@ Tm.Rst {ty; sys}
 
       | _, CoR face0, CoR face1 ->
-        let univ = D.make @@ Univ {lvl = Lvl.Omega; kind = Kind.Pre} in
+        let univ = D.make @@ Univ {lvl = `Omega; kind = `Pre} in
         let face = equate_val_face env univ face0 face1 in
         Tm.make @@ Tm.CoR face
 
@@ -338,7 +338,7 @@ struct
 
       | _, Coe coe0, Coe coe1 ->
         let tr, tr' = equate_dir env coe0.dir coe1.dir in
-        let univ = make @@ Univ {kind = Kind.Pre; lvl = Lvl.Omega} in
+        let univ = make @@ Univ {kind = `Pre; lvl = `Omega} in
         let bnd = equate_val_abs env univ coe0.abs coe1.abs in
         let tyr =
           let r, _ = Dir.unleash coe0.dir in
@@ -429,7 +429,7 @@ struct
 
     | NCoe info0, NCoe info1 ->
       let tr, tr' = equate_dir env info0.dir info1.dir in
-      let univ = make @@ Univ {kind = Kind.Pre; lvl = Lvl.Omega} in
+      let univ = make @@ Univ {kind = `Pre; lvl = `Omega} in
       let bnd = equate_val_abs env univ info0.abs info1.abs in
       let tm = equate_neu env info0.neu info1.neu in
       Tm.Coe {r = tr; r' = tr'; ty = bnd; tm = Tm.up tm}, Bwd.from_list stk
@@ -538,7 +538,7 @@ struct
     | Cap cap0, Cap cap1 ->
       let tr, tr' = equate_dir env cap0.dir cap1.dir in
       let ty = equate_ty env cap0.ty cap1.ty in
-      let univ = make @@ Univ {kind = Kind.Pre; lvl = Lvl.Omega} in
+      let univ = make @@ Univ {kind = `Pre; lvl = `Omega} in
       let sys = equate_comp_sys env univ cap0.sys cap1.sys in
       let frame = Tm.Cap {r = tr; r' = tr'; ty; sys} in
       equate_neu_ env cap0.neu cap1.neu @@ frame :: stk
@@ -564,7 +564,7 @@ struct
     equate_neu_ env neu0 neu1 []
 
   and equate_ty env ty0 ty1 =
-    let univ = make @@ Univ {kind = Kind.Pre; lvl = Lvl.Omega} in
+    let univ = make @@ Univ {kind = `Pre; lvl = `Omega} in
     equate env univ ty0 ty1
 
 

--- a/src/core/Quote.mli
+++ b/src/core/Quote.mli
@@ -41,7 +41,7 @@ sig
     : env
     -> Desc.data_label
     -> (Tm.tm, Tm.tm Desc.Boundary.term) Desc.desc
-    -> Tm.tm Desc.arg_ty
+    -> Tm.tm Desc.rec_spec
     -> value
     -> value
     -> unit

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -213,9 +213,12 @@ let rec check cx ty tm =
     let ty1 = check_eval cx ty info.ty1 in
     check_is_equivalence cx ~ty0 ~ty1 ~equiv:info.equiv
 
-  | D.Univ _, T.Data dlbl ->
-    let _ = GlobalEnv.lookup_datatype dlbl @@ Cx.globals cx in
-    ()
+  | D.Univ univ, T.Data dlbl ->
+    let desc = GlobalEnv.lookup_datatype dlbl @@ Cx.globals cx in
+    if Lvl.lte desc.lvl univ.lvl && Kind.lte desc.kind univ.kind then
+      ()
+    else
+      failwith "Universe level/kind error"
 
   | D.Data dlbl, T.Intro (dlbl', clbl, args) when dlbl = dlbl' ->
     let desc = GlobalEnv.lookup_datatype dlbl @@ Cx.globals cx in

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -181,19 +181,19 @@ let rec check cx ty tm =
   | D.Univ univ, T.Ext (NB (nms, (cod, sys))) ->
     let cxx, xs = Cx.ext_dims cx ~nms:(Bwd.to_list nms) in
     let vcod = check_eval cxx ty cod in
-    if Kind.lte univ.kind Kind.Kan then
+    if Kind.lte univ.kind `Kan then
       check_extension_cofibration xs @@ cofibration_of_sys cxx sys
     else
       ();
     check_ext_sys cxx vcod sys
 
   | D.Univ univ, T.Rst info ->
-    if univ.kind = Kind.Pre then () else failwith "Restriction type is not Kan";
+    if univ.kind = `Pre then () else failwith "Restriction type is not Kan";
     let ty = check_eval cx ty info.ty in
     check_ext_sys cx ty info.sys
 
   | D.Univ univ, T.CoR (tr, tr', oty) ->
-    if univ.kind = Kind.Pre then () else failwith "Co-restriction type is not known to be Kan";
+    if univ.kind = `Pre then () else failwith "Co-restriction type is not known to be Kan";
     let r = check_eval_dim cx tr in
     let r' = check_eval_dim cx tr' in
     begin
@@ -769,7 +769,7 @@ and check_eval cx ty tm =
   Cx.eval cx tm
 
 and check_ty cx ty =
-  let univ = D.make @@ D.Univ {kind = Kind.Pre; lvl = Lvl.Omega} in
+  let univ = D.make @@ D.Univ {kind = `Pre; lvl = `Omega} in
   check cx univ ty
 
 and check_eval_dim cx tr =

--- a/src/frontend/Dev.ml
+++ b/src/frontend/Dev.ml
@@ -31,7 +31,7 @@ type 'a param =
   | `P of 'a
   | `Tw of 'a * 'a
   | `R of 'a * 'a
-  | `SelfArg of 'a Desc.arg_ty
+  | `SelfArg of 'a Desc.rec_spec
   ]
 
 type params = (Name.t * ty param) bwd

--- a/src/frontend/Dev.ml
+++ b/src/frontend/Dev.ml
@@ -345,12 +345,12 @@ let subst_decl sub ~ty =
   | Defn (opacity, t) ->
     Defn (opacity, subst_tm sub ~ty t)
   | Guess info ->
-    let univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Pre in
+    let univ = Tm.univ ~lvl:`Omega ~kind:`Pre in
     let ty' = subst_tm sub ~ty:univ info.ty in
     Guess {ty = ty'; tm = subst_tm sub ~ty:ty' info.tm}
 
 let subst_equation sub q =
-  let univ = Tm.univ ~kind:Kind.Pre ~lvl:Lvl.Omega in
+  let univ = Tm.univ ~kind:`Pre ~lvl:`Omega in
   let ty0 = subst_tm sub ~ty:univ q.ty0 in
   let ty1 = subst_tm sub ~ty:univ q.ty1 in
   let tm0 = subst_tm sub ~ty:ty0 q.tm0 in
@@ -358,7 +358,7 @@ let subst_equation sub q =
   {ty0; ty1; tm0; tm1}
 
 let subst_param sub =
-  let univ = Tm.univ ~kind:Kind.Pre ~lvl:Lvl.Omega in
+  let univ = Tm.univ ~kind:`Pre ~lvl:`Omega in
   function
   | (`I | `Tick | `Lock | `ClearLocks | `SelfArg Desc.Self) as p ->
     p, sub
@@ -373,7 +373,7 @@ let subst_param sub =
     `R (r0, r1), GlobalEnv.restrict r0 r1 sub
 
 let rec subst_problem sub =
-  let univ = Tm.univ ~kind:Kind.Pre ~lvl:Lvl.Omega in
+  let univ = Tm.univ ~kind:`Pre ~lvl:`Omega in
   function
   | Unify q ->
     Unify (subst_equation sub q)
@@ -409,7 +409,7 @@ let rec subst_problem sub =
 let subst_entry sub =
   function
   | E (x, ty, decl) ->
-    let univ = Tm.univ ~kind:Kind.Pre ~lvl:Lvl.Omega in
+    let univ = Tm.univ ~kind:`Pre ~lvl:`Omega in
     E (x, subst_tm sub ~ty:univ ty, subst_decl sub ~ty decl)
   | Q (s, p) ->
     let p' = subst_problem sub p in

--- a/src/frontend/Dev.mli
+++ b/src/frontend/Dev.mli
@@ -28,7 +28,7 @@ type 'a param =
   | `P of 'a
   | `Tw of 'a * 'a
   | `R of 'a * 'a
-  | `SelfArg of 'a Desc.arg_ty
+  | `SelfArg of 'a Desc.rec_spec
   ]
 
 type params = (Name.t * ty param) bwd

--- a/src/frontend/ESig.ml
+++ b/src/frontend/ESig.ml
@@ -30,7 +30,7 @@ and econ =
   | Hope
   | Lam of string list * eterm
   | Tuple of eterm list
-  | Type of Kind.t
+  | Type of Kind.t * Lvl.t
   | Quo of (ResEnv.t -> Tm.tm)
   | Let of {name : string; ty : eterm option; tm : eterm; body : eterm}
 

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -38,7 +38,7 @@ struct
     | Chk of ty
     | Inf
 
-  let univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Pre
+  let univ = Tm.univ ~lvl:`Omega ~kind:`Pre
 
   let get_resolver env =
     let rec go_globals renv  =
@@ -216,7 +216,7 @@ struct
 
       | (lbl, ety) :: const_specs ->
         (* TODO: support higher universes *)
-        let univ0 = Tm.univ ~kind:Kind.Kan ~lvl:(Lvl.Const 0) in
+        let univ0 = Tm.univ ~kind:`Kan ~lvl:(`Const 0) in
         elab_chk env univ0 ety >>= bind_in_scope >>= fun pty ->
         let x = Name.named @@ Some lbl in
         M.in_scope x (`P pty) @@
@@ -545,10 +545,10 @@ struct
 
     | Tm.Univ info, Type kind ->
       begin
-        if Lvl.greater info.lvl (Lvl.Const 0) then
+        if Lvl.greater info.lvl (`Const 0) then
           match Tm.unleash ty with
           | Tm.Univ _ ->
-            M.ret @@ Tm.univ ~kind ~lvl:(Lvl.Const 0)
+            M.ret @@ Tm.univ ~kind ~lvl:(`Const 0)
           | _ ->
             failwith "Type"
         else
@@ -561,7 +561,7 @@ struct
     | _, E.HCom info ->
       elab_dim env info.r >>= fun r ->
       elab_dim env info.r' >>= fun r' ->
-      let kan_univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kan in
+      let kan_univ = Tm.univ ~lvl:`Omega ~kind:`Kan in
       begin
         M.lift @@ C.check ~ty:kan_univ ty >>= function
         | `Ok ->
@@ -704,7 +704,7 @@ struct
         M.lift C.base_cx <<@> fun cx ->
           let sign = Cx.globals cx in
           let _ = GlobalEnv.lookup_datatype name sign in
-          let univ0 = Tm.univ ~kind:Kind.Kan ~lvl:(Lvl.Const 0) in
+          let univ0 = Tm.univ ~kind:`Kan ~lvl:(`Const 0) in
           univ0, Tm.ann ~ty:univ0 ~tm:(Tm.make @@ Tm.Data name)
       end
 
@@ -728,7 +728,7 @@ struct
       elab_dim env info.r >>= fun tr ->
       elab_dim env info.r' >>= fun tr' ->
       let x = Name.fresh () in
-      let kan_univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Kan in
+      let kan_univ = Tm.univ ~lvl:`Omega ~kind:`Kan in
       let univ_fam = Tm.make @@ Tm.Ext (Tm.bind_ext (Emp #< x) kan_univ []) in
       elab_chk env univ_fam info.fam >>= fun fam ->
       begin
@@ -746,7 +746,7 @@ struct
       elab_dim env info.r >>= fun tr ->
       elab_dim env info.r' >>= fun tr' ->
       let x = Name.fresh () in
-      let kan_univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Kan in
+      let kan_univ = Tm.univ ~lvl:`Omega ~kind:`Kan in
       let univ_fam = Tm.make @@ Tm.Ext (Tm.bind_ext (Emp #< x) kan_univ []) in
       elab_chk env univ_fam info.fam >>= fun fam ->
       M.lift @@ (univ_fam, fam) %% Tm.ExtApp [tr] >>= fun (_, fam_r) ->

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -181,7 +181,7 @@ struct
       failwith "Duplicate constructor in datatype";
 
     let open Desc in
-    let elab_arg_ty (x, Self) = M.ret (x, Self) in
+    let elab_rec_spec (x, Self) = M.ret (x, Self) in
 
     let rec abstract_tele xs (ps : _ list) =
       match ps with
@@ -197,7 +197,7 @@ struct
         let const_specs = abstract_tele Emp @@ Bwd.to_list acc in
         (* TODO: when self args are more complex, we'll need to abstract them over
            the parameters too. *)
-        traverse elab_arg_ty constr.rec_specs >>= fun rec_specs ->
+        traverse elab_rec_spec constr.rec_specs >>= fun rec_specs ->
 
         let psi =
           List.map (fun (nm, ty) -> (Name.named @@ Some nm, `SelfArg ty)) rec_specs
@@ -314,13 +314,13 @@ struct
           failwith "elab_intro: malformed parameters"
       in
 
-      let rec go_args acc arg_tys frms =
-        match arg_tys, frms with
+      let rec go_args acc rec_specs frms =
+        match rec_specs, frms with
         | [], _ ->
           M.ret (Bwd.to_list acc, frms)
-        | (_, Desc.Self) :: arg_tys, E.App e :: frms ->
+        | (_, Desc.Self) :: rec_specs, E.App e :: frms ->
           elab_boundary_term env dlbl desc e >>= fun bt ->
-          go_args (acc #< bt) arg_tys frms
+          go_args (acc #< bt) rec_specs frms
         | _ ->
           failwith "todo: go_args"
       in

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -174,7 +174,11 @@ struct
         elab_constr env dlbl acc econstr >>= fun constr ->
         go Desc.{edesc with constrs = acc.constrs @ [constr]} econstrs
     in
-    go Desc.{edesc with constrs = []} edesc.constrs
+    match edesc.kind with
+    | `Reg ->
+      failwith "elab_datatype: Not yet sure what conditions need to be checked for `Reg kind"
+    | _ ->
+      go Desc.{edesc with constrs = []} edesc.constrs
 
   and elab_constr env dlbl desc (clbl, constr) =
     if List.exists (fun (lbl, _) -> clbl = lbl) desc.constrs then
@@ -216,8 +220,8 @@ struct
 
       | (lbl, ety) :: const_specs ->
         (* TODO: support higher universes *)
-        let univ0 = Tm.univ ~kind:`Kan ~lvl:(`Const 0) in
-        elab_chk env univ0 ety >>= bind_in_scope >>= fun pty ->
+        let univ = Tm.univ ~kind:desc.kind ~lvl:desc.lvl in
+        elab_chk env univ ety >>= bind_in_scope >>= fun pty ->
         let x = Name.named @@ Some lbl in
         M.in_scope x (`P pty) @@
         go (acc #< (lbl, x, pty)) const_specs

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -543,12 +543,12 @@ struct
       let cod' = Tm.make @@ Tm.Let (cmd0, cod) in
       elab_chk env cod' {e with con = E.Tuple es} <<@> Tm.cons tm0
 
-    | Tm.Univ info, Type kind ->
+    | Tm.Univ info, Type (kind, lvl) ->
       begin
-        if Lvl.greater info.lvl (`Const 0) then
+        if Lvl.greater info.lvl lvl then
           match Tm.unleash ty with
           | Tm.Univ _ ->
-            M.ret @@ Tm.univ ~kind ~lvl:(`Const 0)
+            M.ret @@ Tm.univ ~kind ~lvl
           | _ ->
             failwith "Type"
         else

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -38,10 +38,16 @@ edecl:
     { E.Debug f }
 
   | DATA; dlbl = ATOM;
+    univ_spec = option(preceded(COLON, univ_spec));
     WHERE; option(PIPE);
     constrs = separated_list(PIPE, desc_constr)
     { let desc = List.map (fun constr -> constr dlbl) constrs in
-      E.Data (dlbl, {constrs = desc}) }
+      let kind, lvl =
+        match univ_spec with
+        | Some (k, l) -> k, l
+        | None -> `Kan, `Const 0
+      in
+      E.Data (dlbl, {constrs = desc; kind; lvl}) }
 
   | IMPORT; a = ATOM
     { E.Import a }

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -315,10 +315,10 @@ constrained:
 
 kind:
   | KAN
-    { Kind.Kan }
+    { `Kan }
   | PRE
-    { Kind.Pre }
-  | { Kind.Kan }
+    { `Pre }
+  | { `Kan }
 
 tm:
   | BULLET
@@ -332,7 +332,7 @@ tm:
   | LPR; UNIV; k = kind; i = NUMERAL; RPR
     { fun _env ->
       make_node $startpos $endpos @@
-      Tm.Univ {kind = k; lvl = Lvl.Const i} }
+      Tm.Univ {kind = k; lvl = `Const i} }
 
   | LPR; V; r = tm; ty0 = tm; ty1 = tm; equiv = tm; RPR
     { fun env ->

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -36,13 +36,24 @@ edecl:
     { E.Define (a, `Opaque, sch, tm) }
   | DEBUG; f = debug_filter
     { E.Debug f }
-  | DATA; dlbl = ATOM; WHERE; option(PIPE); constrs = separated_list(PIPE, desc_constr)
+
+  | DATA; dlbl = ATOM;
+    WHERE; option(PIPE);
+    constrs = separated_list(PIPE, desc_constr)
     { let desc = List.map (fun constr -> constr dlbl) constrs in
       E.Data (dlbl, {constrs = desc}) }
+
   | IMPORT; a = ATOM
     { E.Import a }
   | QUIT
     { E.Quit }
+
+univ_spec:
+  | TYPE; k = kind
+    { (k, `Const 0) }
+  | TYPE; k = kind; CARET; l = NUMERAL
+    { (k, `Const l) }
+
 
 debug_filter:
   | { `All }
@@ -59,8 +70,8 @@ atomic_econ:
     { E.Hole a }
   | HOLE_NAME; LBR; e = eterm; RBR
     { E.Guess e }
-  | TYPE; k = kind
-    { E.Type k }
+  | spec = univ_spec
+    { let k, l = spec in E.Type (k, l) }
   | LGL; es = separated_list(COMMA, eterm); RGL
     { E.Tuple es }
   | LPR; e = eterm; RPR

--- a/src/frontend/Refiner.ml
+++ b/src/frontend/Refiner.ml
@@ -227,7 +227,7 @@ let make_motive ~data_ty ~tac_mot ~scrut ~ty =
   | None ->
     guess_motive scrut ty
   | Some tac_mot ->
-    let univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Pre in
+    let univ = Tm.univ ~lvl:`Omega ~kind:`Pre in
     let mot_ty = Tm.pi None data_ty univ in
     tac_mot mot_ty >>= fun mot ->
     let motx =

--- a/src/frontend/Unify.ml
+++ b/src/frontend/Unify.ml
@@ -592,7 +592,7 @@ let restriction_subtype ty0 sys0 ty1 sys1 =
 (* invariant: will not be called on inequations which are already reflexive *)
 let rec subtype ty0 ty1 =
   if ty0 = ty1 then ret () else
-    let univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Pre in
+    let univ = Tm.univ ~lvl:`Omega ~kind:`Pre in
     match Tm.unleash ty0, Tm.unleash ty1 with
     | Tm.Pi (dom0, cod0), Tm.Pi (dom1, cod1) ->
       let x = Name.fresh () in
@@ -849,7 +849,7 @@ let rec lower tele alpha ty =
     ret false
 
 let is_reflexive q =
-  let univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Pre in
+  let univ = Tm.univ ~lvl:`Omega ~kind:`Pre in
   check_eq ~ty:univ q.ty0 q.ty1 >>= function
   | `Ok ->
     begin
@@ -905,7 +905,7 @@ let rec solver prob =
           end
 
         | `Tw (ty0, ty1) ->
-          let univ = Tm.univ ~lvl:Lvl.Omega ~kind:Kind.Pre in
+          let univ = Tm.univ ~lvl:`Omega ~kind:`Pre in
           begin
             check_eq ~ty:univ ty0 ty1 >>= function
             | `Ok ->

--- a/src/frontend/Unify.ml
+++ b/src/frontend/Unify.ml
@@ -372,11 +372,11 @@ let evaluator =
   base_cx >>= fun cx ->
   ret (cx, Cx.evaluator cx)
 
-let inst_ty_bnd bnd (arg_ty, arg) =
+let inst_ty_bnd bnd (rec_spec, arg) =
   base_cx >>= fun cx ->
   let Tm.B (nm, tm) = bnd in
   let varg = Cx.eval cx arg in
-  let lcx = Cx.def cx ~nm ~ty:arg_ty ~el:varg in
+  let lcx = Cx.def cx ~nm ~ty:rec_spec ~el:varg in
   ret @@ Cx.quote_ty cx @@ Cx.eval lcx tm
 
 let eval tm =
@@ -384,11 +384,11 @@ let eval tm =
   ret @@ Cx.eval cx tm
 
 
-let inst_bnd (ty_clo, tm_bnd) (arg_ty, arg) =
+let inst_bnd (ty_clo, tm_bnd) (rec_spec, arg) =
   evaluator >>= fun (cx, (module V)) ->
   let Tm.B (nm, tm) = tm_bnd in
   let varg = Cx.eval cx arg in
-  let lcx = Cx.def cx ~nm ~ty:arg_ty ~el:varg in
+  let lcx = Cx.def cx ~nm ~ty:rec_spec ~el:varg in
   let vty = V.inst_clo ty_clo varg in
   ret @@ Cx.quote cx ~ty:vty @@ Cx.eval lcx tm
 


### PR DESCRIPTION
Resolves #203 

You can now declare a HIT with explicit level and kind, like:

```
data foo : type kan ^1 where
| con [A : type]
```

This branch also contains some renaming and general cleanup.