### PR TITLE
Fix bad dimension bug

### DIFF
--- a/example/omega1s1.red
+++ b/example/omega1s1.red
@@ -80,7 +80,7 @@ let winding-loopn (n : int) : Path int (winding (loopn n)) n =
 ;    ]
 ;  ]
 
-; the following symmetry version avoids the bug (thanks to Evan).
+; the following symmetric version uses vproj instead of coe in V (thanks to Evan).
 
 let decode-square (n : int)
   : [i j] s1 [

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -716,7 +716,6 @@ struct
        * safer to do substitution every time. *)
       let recovery_apart phi abs x_dest z_dest =
         let subst_x = I.subst x_dest x in
-
         make_coe (Dir.make (I.act (I.cmp subst_x phi) s') (I.act subst_x z_dest)) (Abs.act subst_x abs) @@
         make_coe (Dir.make (I.act phi r) x_dest) (Abs.bind1 x @@ Abs.inst1 abs (I.act phi s')) @@
         Value.act phi el
@@ -779,7 +778,6 @@ struct
         in
         diag :: List.map (fun b -> face (AbsFace.act subst_r' b)) fhcom.sys
       in
-
       make_box (Dir.act subst_r' fhcom.dir) coerced_cap @@
       force_val_sys @@
       let face =

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -716,7 +716,8 @@ struct
        * safer to do substitution every time. *)
       let recovery_apart phi abs x_dest z_dest =
         let subst_x = I.subst x_dest x in
-        make_coe (Dir.make (I.act (I.cmp subst_x phi) s') (I.act subst_x z_dest)) abs @@
+
+        make_coe (Dir.make (I.act (I.cmp subst_x phi) s') (I.act subst_x z_dest)) (Abs.act subst_x abs) @@
         make_coe (Dir.make (I.act phi r) x_dest) (Abs.bind1 x @@ Abs.inst1 abs (I.act phi s')) @@
         Value.act phi el
       in

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -778,13 +778,15 @@ struct
         in
         diag :: List.map (fun b -> face (AbsFace.act subst_r' b)) fhcom.sys
       in
+
       make_box (Dir.act subst_r' fhcom.dir) coerced_cap @@
       force_val_sys @@
       let face =
         Face.map @@ fun sj s'j absj ->
         let phi = I.equate sj s'j in
         recovery_general phi absj (I.act (I.cmp phi subst_r') s')
-      in List.map (fun b -> face (AbsFace.act subst_r' b)) fhcom.sys
+      in
+      List.map (fun b -> face (AbsFace.act subst_r' b)) fhcom.sys
 
 
     | V info ->


### PR DESCRIPTION
Resolves #253 

I think I have discovered the source of the very mysterious bug that has been owning us for two weeks, in which there was some dimension that left its scope.

My hypothesis 1.5 weeks ago was that the bug was somewhere in `coe/fhcom`, and I think it was borne out. The change I make here allows the following code to work, which used to throw an error:

```
import path
import unit

data O where
| obase @ i []

let encode_ty (p : Path unit triv triv) (i : dim) : type =
  elim (p i) [ triv ⇒ O ]

let decode (o : O) : Path unit triv triv =
  elim o [
  | obase i ⇒ λ j →
    comp 0 1 triv [
    | j=0 ⇒ λ c → triv
    | j=1 ⇒ λ d → triv
    | i=0 ⇒ λ _ → ?
    ]
  ]


let bad-ty (o : O) (k : dim) : _ =
  coe 0 1 (obase 0) in encode_ty (decode (obase k))

; this is the part that would fail before:
normalize bad-ty
```

Looking at the algorithm from Part III, I think that this substitution does need to be placed here. But I'd appreciate another couple pairs of eyes.