### PR TITLE
fix s3-to-join, maybe

### DIFF
--- a/example/s3-to-join.red
+++ b/example/s3-to-join.red
@@ -21,44 +21,45 @@ data join where
   | i=1 → inr b
   ]
 
-; somebody oughta check this is an equivalence!
+; forward map
+
+; pseudo-connection
+let s3-to-join/cnx (b : s1) (i m : dim) : join =
+  comp 0 i (inl base) [
+  | m=0 → refl
+  | m=1 → λ i → push base b i
+  ]
+
+let s3-to-join/k01 : [i j m] join [
+  | i=1 → s3-to-join/cnx base 1 m
+  | j=0 → s3-to-join/cnx base i m
+  | j=1 → s3-to-join/cnx base i m
+  | m=0 → inl base
+  | m=1 → push (loop j) base i
+  ]
+  =
+  λ i j m →
+    comp 1 i (s3-to-join/cnx base 1 m) [
+    | j=0 → λ i → s3-to-join/cnx base i m
+    | j=1 → λ i → s3-to-join/cnx base i m
+    | m=0 → λ _ → inl base
+    | m=1 → λ i → push (loop j) base i
+    ]
+
+let s3-to-join/cube/filler (i j k x : dim) : join =
+  comp 1 x (push (loop j) (loop k) i) [
+  | i=0 → λ m → s3-to-join/k01 0 j m
+  | i=1 → λ m → s3-to-join/cnx (loop k) 1 m
+  | j=0 → λ m → s3-to-join/cnx (loop k) i m
+  | j=1 → λ m → s3-to-join/cnx (loop k) i m
+  | k=0 → λ m → s3-to-join/k01 i j m
+  | k=1 → λ m → s3-to-join/k01 i j m
+  ]
 
 let s3-to-join (d : s3) : join =
-  ; approximate connection
-  let cnx : (i k m : dim) → join =
-    λ i k m →
-      comp 0 i (inl base) [
-      | m=0 → refl
-      | m=1 → λ i → push base (loop k) i
-      ]
-  in
-  let face/k01 : [i j m] join [
-    | i=1 → cnx 1 0 m
-    | j=0 → cnx i 0 m
-    | j=1 → cnx i 0 m
-    | m=0 → inl base
-    | m=1 → push (loop j) base i
-    ]
-    =
-    λ i j m →
-      comp 1 i (cnx 1 0 m) [
-      | j=0 → λ i → cnx i 0 m
-      | j=1 → λ i → cnx i 0 m
-      | m=0 → λ _ → inl base
-      | m=1 → λ i → push (loop j) base i
-      ]
- in
   elim d [
   | base → inl base
-  | cube i j k →
-    comp 1 0 (push (loop j) (loop k) i) [
-    | i=0 → λ m → face/k01 0 j m
-    | i=1 → λ m → cnx 1 k m
-    | j=0 → λ m → cnx i k m
-    | j=1 → λ m → cnx i k m
-    | k=0 → λ m → face/k01 i j m
-    | k=1 → λ m → face/k01 i j m
-    ]
+  | cube i j k → s3-to-join/cube/filler i j k 0
   ]
 
 ; inverse map
@@ -82,6 +83,47 @@ let join-to-s3 (c : join) : s3 =
   | inl a → base
   | inr b → base
   | push a b i → join-to-s3/push a b i
+  ]
+
+; join-s3-join inverse homotopy
+
+let join-s3-join/inl (a : s1) : Path join (inl base) (inl a) =
+  elim a [
+  | base → refl
+  | loop j → λ x → s3-to-join/k01 0 j x
+  ]
+
+let join-s3-join/push/loop (b : s1) : [i j x] join [
+  | i=0 → s3-to-join/k01 0 j x
+  | i=1 → s3-to-join/cnx b 1 x
+  | j=0 → s3-to-join/cnx b i x
+  | j=1 → s3-to-join/cnx b i x
+  | x=0 → s3-to-join (join-to-s3/push/loop b i j)
+  | x=1 → push (loop j) b i
+  ]
+  =
+  elim b [
+  | base → λ i j x → s3-to-join/k01 i j x
+  | loop k → λ i j x → s3-to-join/cube/filler i j k x
+  ]
+
+let join-s3-join/push (a b : s1) : [i x] join [
+  | i=0 → join-s3-join/inl a x
+  | i=1 → s3-to-join/cnx b 1 x
+  | x=0 → s3-to-join (join-to-s3/push a b i)
+  | x=1 → push a b i
+  ]
+  =
+  elim a [
+  | base → λ i x → s3-to-join/cnx b i x
+  | loop j → λ i x → join-s3-join/push/loop b i j x
+  ]
+
+let join-s3-join (c : join) : Path join (s3-to-join (join-to-s3 c)) c =
+  elim c [
+  | inl a → λ x → join-s3-join/inl a x
+  | inr b → λ x → s3-to-join/cnx b 1 x
+  | push a b i → λ x → join-s3-join/push a b i x
   ]
 
 ; adapted from "alpha" in cubicaltt:

--- a/example/s3-to-join.red
+++ b/example/s3-to-join.red
@@ -24,18 +24,26 @@ data join where
 ; somebody oughta check this is an equivalence!
 
 let s3-to-join (d : s3) : join =
+  ; approximate connection
+  let cnx : (i k m : dim) → join =
+    λ i k m →
+      comp 0 i (inl base) [
+      | m=0 → refl
+      | m=1 → λ i → push base (loop k) i
+      ]
+  in
   let face/k01 : [i j m] join [
-    | i=1 → push base base m
-    | j=0 → weak-connection/and join (λ n → push base base n) i m
-    | j=1 → weak-connection/and join (λ n → push base base n) i m
+    | i=1 → cnx 1 0 m
+    | j=0 → cnx i 0 m
+    | j=1 → cnx i 0 m
     | m=0 → inl base
     | m=1 → push (loop j) base i
     ]
     =
     λ i j m →
-      comp 1 i (push base base m) [
-      | j=0 → λ i → weak-connection/and join (λ n → push base base n) i m
-      | j=1 → λ i → weak-connection/and join (λ n → push base base n) i m
+      comp 1 i (cnx 1 0 m) [
+      | j=0 → λ i → cnx i 0 m
+      | j=1 → λ i → cnx i 0 m
       | m=0 → λ _ → inl base
       | m=1 → λ i → push (loop j) base i
       ]
@@ -45,9 +53,9 @@ let s3-to-join (d : s3) : join =
   | cube i j k →
     comp 1 0 (push (loop j) (loop k) i) [
     | i=0 → λ m → face/k01 0 j m
-    | i=1 → λ m → push base (loop k) m
-    | j=0 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
-    | j=1 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
+    | i=1 → λ m → cnx 1 k m
+    | j=0 → λ m → cnx i k m
+    | j=1 → λ m → cnx i k m
     | k=0 → λ m → face/k01 i j m
     | k=1 → λ m → face/k01 i j m
     ]
@@ -66,7 +74,7 @@ let join-to-s3/push/loop (b : s1)
 let join-to-s3/push (a b : s1) : Path s3 base base =
   elim a [
   | base → λ _ → base
-  | loop i → λ j → join-to-s3/push/loop b i j
+  | loop j → λ i → join-to-s3/push/loop b i j
   ]
 
 let join-to-s3 (c : join) : s3 =

--- a/example/s3-to-join.red
+++ b/example/s3-to-join.red
@@ -39,29 +39,18 @@ let s3-to-join (d : s3) : join =
       | m=0 → λ _ → inl base
       | m=1 → λ i → push (loop j) base i
       ]
-  in
-  let cube' : [i j k] join [
-    | i=0 → inl base
-    | i=1 → inl base
-    | j=0 → inl base
-    | j=1 → inl base
-    | k=0 → inl base
-    | k=1 → inl base
-    ]
-    =
-    λ i j k →
-      comp 1 0 (push (loop j) (loop k) i) [
-      | i=0 → λ m → face/k01 0 j m
-      | i=1 → λ m → push base (loop k) m
-      | j=0 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
-      | j=1 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
-      | k=0 → λ m → face/k01 i j m
-      | k=1 → λ m → face/k01 i j m
-      ]
-  in
+ in
   elim d [
   | base → inl base
-  | cube i j k → cube' i j k
+  | cube i j k →
+    comp 1 0 (push (loop j) (loop k) i) [
+    | i=0 → λ m → face/k01 0 j m
+    | i=1 → λ m → push base (loop k) m
+    | j=0 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
+    | j=1 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
+    | k=0 → λ m → face/k01 i j m
+    | k=1 → λ m → face/k01 i j m
+    ]
   ]
 
 ; inverse map

--- a/example/s3-to-join.red
+++ b/example/s3-to-join.red
@@ -21,69 +21,26 @@ data join where
   | i=1 → inr b
   ]
 
-; adapted from "e" in cubicaltt:
-; https://github.com/mortberg/cubicaltt/blob/d3afca5a744a96de4831610e76d6c4b629478362/examples/brunerie2.ctt#L298
+; somebody oughta check this is an equivalence!
 
 let s3-to-join (d : s3) : join =
-  ; need to make the faces of this all (inl base)
-  let step0 : [i j k] join [
-    | i=0 → inl (loop j)
-    | i=1 → inr (loop k)
-    | j=0 → push base (loop k) i
-    | j=1 → push base (loop k) i
-    | k=0 → push (loop j) base i
-    | k=1 → push (loop j) base i
+  let face/k01 : [i j m] join [
+    | i=1 → push base base m
+    | j=0 → weak-connection/and join (λ n → push base base n) i m
+    | j=1 → weak-connection/and join (λ n → push base base n) i m
+    | m=0 → inl base
+    | m=1 → push (loop j) base i
     ]
     =
-    λ i j k →
-      push (loop j) (loop k) i
-  in
-  ; like a connection, but we don't need to know all the faces
-  let filler1 : [j m] s1 [
-    | m=0 → loop j
-    | m=1 → base
-    ]
-    =
-    λ j m →
-      comp 0 j base [
-      | m=0 → λ j → loop j
-      | m=1 → λ _ → base
+    λ i j m →
+      comp 1 i (push base base m) [
+      | j=0 → λ i → weak-connection/and join (λ n → push base base n) i m
+      | j=1 → λ i → weak-connection/and join (λ n → push base base n) i m
+      | m=0 → λ _ → inl base
+      | m=1 → λ i → push (loop j) base i
       ]
   in
-  ; get rid of loops
-  let step1 : [i j k] join [
-    | i=0 → inl base
-    | i=1 → inr base
-    | j=0 → push base base i
-    | j=1 → push base base i
-    | k=0 → push base base i
-    | k=1 → push base base i
-    ]
-    =
-    λ i j k →
-      comp 0 1 (step0 i j k) [
-      | i=0 → λ m → inl (filler1 j m)
-      | i=1 → λ m → inr (filler1 k m)
-      | j=0 → λ m → push (filler1 0 m) (filler1 k m) i
-      | j=1 → λ m → push (filler1 1 m) (filler1 k m) i
-      | k=0 → λ m → push (filler1 j m) (filler1 0 m) i
-      | k=1 → λ m → push (filler1 j m) (filler1 1 m) i
-      ]
-  in
-  ; like a connection, but we don't need to know all the faces
-  let filler2 : [i m] join [
-    | m=0 → push base base i
-    | m=1 → inl base
-    ]
-    =
-    λ i m →
-      comp 0 i (inl base) [
-      | m=0 → λ i → push base base i
-      | m=1 → λ _ → inl base
-      ]
-  in
-  ; get rid of push
-  let step2 : [i j k] join [
+  let cube' : [i j k] join [
     | i=0 → inl base
     | i=1 → inl base
     | j=0 → inl base
@@ -93,18 +50,18 @@ let s3-to-join (d : s3) : join =
     ]
     =
     λ i j k →
-      comp 0 1 (step1 i j k) [
-      | i=0 → λ _ → inl base
-      | i=1 → λ m → filler2 1 m
-      | j=0 → λ m → filler2 i m
-      | j=1 → λ m → filler2 i m
-      | k=0 → λ m → filler2 i m
-      | k=1 → λ m → filler2 i m
+      comp 1 0 (push (loop j) (loop k) i) [
+      | i=0 → λ m → face/k01 0 j m
+      | i=1 → λ m → push base (loop k) m
+      | j=0 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
+      | j=1 → λ m → weak-connection/and join (λ n → push base (loop k) n) i m
+      | k=0 → λ m → face/k01 i j m
+      | k=1 → λ m → face/k01 i j m
       ]
   in
   elim d [
   | base → inl base
-  | cube i j k → step2 i j k
+  | cube i j k → cube' i j k
   ]
 
 ; inverse map


### PR DESCRIPTION
The current definition of this "equivalence" is actually homotopic to a constant map. This one is less likely to be, since none of the boundary-fixing uses of `push` involve all the variables `i`,`j`,`k`. But we should really prove it is an equivalence to be sure.

@mortberg I bet this version would look real nice in cubicaltt