### PR TITLE
apply Guillaume's Thought

### DIFF
--- a/example/problem.red
+++ b/example/problem.red
@@ -36,6 +36,8 @@ let f4 : pΩ³ pjoin .fst → pΩ³ ps2 .fst =
 
 let test0-4 : pΩ³ ps2 .fst = f4 test0-3
 
-; haven't seen this finish checking
-;let innerpath (i j : dim) : s1 =
-;  coe 0 1 base in λ k → hopf (test0-4 i j k)
+let innerpath (i j : dim) : s1 =
+  coe 0 1 base in λ k → hopf (test0-4 i j k)
+
+;let problem : Path int (pos zero) (pos zero) =
+;  λ i → coe 0 1 (pos zero) in λ j → s1-univ-cover (innerpath i j)

--- a/example/s2.red
+++ b/example/s2.red
@@ -15,10 +15,10 @@ let hopf (a : s2) : type =
   elim a [
   | base → s1
   | surf i j →
-    comp 0 1 (rotate/path (loop j) i) [
-    | i=0 → refl
-    | i=1 → refl
-    | j=0 k → UA/IdEquiv s1 k i
-    | j=1 k → UA/IdEquiv s1 k i
+    comp 0 1 s1 [
+    | j=0 → UA s1 s1 (IdEquiv s1)
+    | j=1 → UA s1 s1 (IdEquiv s1)
+    | i=0 → UA s1 s1 (IdEquiv s1)
+    | i=1 → rotate/path (loop j)
     ]
   ]

--- a/example/univalence.red
+++ b/example/univalence.red
@@ -73,11 +73,8 @@ let LemSig
   =
   λ i →
     ( P i
-    , let coe0 = coe 0 i (u.snd) in λ j → B (P j) in
-      let coe1 = coe 1 i (v.snd) in λ j → B (P j) in
-      B/prop (P i) coe0 coe1 i
+    , PropToPropOver (λ i → B (P i)) (B/prop (P 1)) (u.snd) (v.snd) i
     )
-
 
 let PropSig
   (A : type) (B : A → type)
@@ -125,13 +122,27 @@ let PropIsEquivDirect (A B : type) (f : A → B) : IsProp (IsEquiv A B f) =
     in
     ( c' (a , p) i
     , λ w →
-        let sq : PathD (λ j → Path (Fiber A B f y) w (c' (a,p) j)) (c w) (c' w) =
+        let cap : (i j : dim) → Fiber A B f y =
           λ i j →
-            comp 0 1 (weak-connection/and (Fiber A B f y) (c' w) i j) [
-            | i=0 k → weak-connection/and (Fiber A B f y) (c w) k j
+            comp 1 i (c' w j) [
+            | j=0 → refl
+            | j=1 → c' w
+            ]
+        in
+        let face/i0 : (j k : dim) → Fiber A B f y =
+          λ j k →
+            comp 0 j w [
+            | k=0 → cap 0
+            | k=1 → c w
+            ]
+        in
+        let sq : PathD (λ i → Path (Fiber A B f y) w (c' (a,p) i)) (c w) (c' w) =
+          λ i j →
+            comp 0 1 (cap i j) [
+            | i=0 → face/i0 j
             | i=1 _ → c' w j
             | j=0 _ → w
-            | j=1 k → c' (c w k) i
+            | j=1 k → c' (face/i0 1 k) i
             ]
         in
         sq i


### PR DESCRIPTION
to define the Hopf fibration without using the expensive proof that UA IdEquiv is a constant path. With `coe` in datatypes redefined as identity, `innerpath` now checks instantaneously! (Without, it takes ~2sec.)

Waiting to see if `problem` gets anywhere...