### PR TITLE
working toward more flexible favonia-style HIT spec

### DIFF
--- a/example/int.red
+++ b/example/int.red
@@ -6,8 +6,8 @@ import equivalence
 import isotoequiv
 
 data int where
-| pos [n : nat]
-| negsuc [n : nat]
+| pos (n : nat)
+| negsuc (n : nat)
 
 let pred : int → int =
   λ [

--- a/example/omega1s2.red
+++ b/example/omega1s2.red
@@ -11,7 +11,7 @@ import s2
 -- loop space of s2
 data os2 where
 | obase
-| oloop (y : os2) @ i [∂[i] → y]
+| oloop (y : os2) (i : dim) [∂[i] → y]
 
 -- I. the loop of automorphisms of os2
 

--- a/example/s1.red
+++ b/example/s1.red
@@ -5,7 +5,7 @@ import univalence
 
 data s1 where
 | base
-| loop @ i [∂[i] → base]
+| loop (i : dim) [∂[i] → base]
 
 let rotate/loop : (a : s1) → path _ a a =
   λ [

--- a/example/s2.red
+++ b/example/s2.red
@@ -4,7 +4,7 @@ import univalence
 
 data s2 where
 | base
-| surf @ i j [∂[i j] → base]
+| surf (i j : dim) [∂[i j] → base]
 
 let hopf : s2 → type =
   λ [

--- a/example/s3-to-join.red
+++ b/example/s3-to-join.red
@@ -5,12 +5,12 @@ import isotoequiv
 
 data s3 where
 | base
-| cube @ i j k [∂[i j k] → base]
+| cube (i j k : dim) [∂[i j k] → base]
 
 data join where
-| inl [a : s1]
-| inr [b : s1]
-| push [a : s1] [b : s1] @ i [
+| inl (a : s1)
+| inr (b : s1)
+| push (a : s1) (b : s1) (i : dim) [
   | i=0 → inl a
   | i=1 → inr b
   ]

--- a/example/torus.red
+++ b/example/torus.red
@@ -7,9 +7,9 @@ import isotoequiv
 
 data torus where
 | pt
-| p/one @ i [∂[i] → pt]
-| p/two @ i [∂[i] → pt]
-| square @ i j
+| p/one (i : dim) [∂[i] → pt]
+| p/two (i : dim) [∂[i] → pt]
+| square (i j : dim)
   [ ∂[i] → p/one j
   | ∂[j] → p/two i
   ]

--- a/src/core/Desc.ml
+++ b/src/core/Desc.ml
@@ -9,11 +9,34 @@ type con_label = string
 type 'a face = 'a * 'a * 'a option
 type 'a system = 'a face list
 
+type 'a arg_spec =
+  [ `Const of 'a
+  | `Rec of 'a rec_spec
+  | `Dim
+  ]
+
+
 type 'a constr =
-  {const_specs : (string * 'a) list;
-   rec_specs : (string * 'a rec_spec) list;
-   dim_specs : string list;
+  {specs : (string * 'a arg_spec) list;
    boundary : 'a system}
+
+
+let flip f x y = f y x
+
+let dim_specs constr =
+  List.flatten @@ flip List.map constr.specs @@ function
+  | (x, `Dim) -> [x]
+  | _ -> []
+
+let const_specs constr =
+  List.flatten @@ flip List.map constr.specs @@ function
+  | (x, `Const ty) -> [x, ty]
+  | _ -> []
+
+let rec_specs constr =
+  List.flatten @@ flip List.map constr.specs @@ function
+  | (x, `Rec ty) -> [x, ty]
+  | _ -> []
 
 
 (** A datatype description is just a list of named constructors. *)
@@ -35,7 +58,7 @@ let lookup_constr lbl desc =
 
 let is_strict_set desc =
   let constr_is_point constr =
-    match constr.dim_specs with
+    match dim_specs constr with
     | [] -> true
     | _ -> false
   in

--- a/src/core/Desc.mli
+++ b/src/core/Desc.mli
@@ -10,16 +10,20 @@ type con_label = string
 type 'a face = 'a * 'a * 'a option
 type 'a system = 'a face list
 
-(** A data constructor is a list of parameters (non-recursive arguments) and recursive arguments,
-    and dimensions.
+type 'a arg_spec =
+  [ `Const of 'a
+  | `Rec of 'a rec_spec
+  | `Dim
+  ]
 
-    When we generalized to indexed inductive types, the parameters will become {e bound} in the
-    arguments. TODO: rename [args] to [rec_args]. *)
+
 type 'a constr =
-  {const_specs : (string * 'a) list;
-   rec_specs : (string * 'a rec_spec) list;
-   dim_specs : string list;
+  {specs : (string * 'a arg_spec) list;
    boundary : 'a system}
+
+val dim_specs : 'a constr -> string list
+val const_specs : 'a constr -> (string * 'a) list
+val rec_specs : 'a constr -> (string * 'a rec_spec) list
 
 
 (** A datatype description is just a list of named constructors. *)

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -359,7 +359,6 @@ struct
         raise @@ E err
 
   and equate_constr_const_args env constr els0 els1 =
-    let open Desc in
     let rec go acc venv const_specs els0 els1 =
       match const_specs, els0, els1 with
       | [], [], [] ->
@@ -371,13 +370,13 @@ struct
       | _ ->
         failwith "equate_constr_args"
     in
-    go Emp empty_env constr.const_specs els0 els1
+    go Emp empty_env (Desc.const_specs constr) els0 els1
 
   and equate_constr_rec_args env dlbl constr els0 els1 =
     let open Desc in
     (* TODO: factor out *)
     let realize_spec_ty Self = D.make @@ D.Data dlbl in
-    ListUtil.map3 (fun (_, spec_ty) -> equate env @@ realize_spec_ty spec_ty) constr.rec_specs els0 els1
+    ListUtil.map3 (fun (_, spec_ty) -> equate env @@ realize_spec_ty spec_ty) (Desc.rec_specs constr) els0 els1
 
   and equate_neu_ env neu0 neu1 stk =
     match neu0, neu1 with
@@ -514,7 +513,7 @@ struct
               | [], [], [] ->
                 qenv, Bwd.to_list vs, Bwd.to_list cvs, Bwd.to_list rvs, Bwd.to_list rs
             in
-            build_cx env empty_env (Emp, Emp, Emp) Emp constr.const_specs constr.rec_specs constr.dim_specs
+            build_cx env empty_env (Emp, Emp, Emp) Emp (Desc.const_specs constr) (Desc.rec_specs constr) (Desc.dim_specs constr)
           in
           let cells = List.map (fun x -> `Val x) vs @ List.map (fun x -> `Dim x) rs in
           let bdy0 = inst_nclo clause0 cells in
@@ -900,7 +899,7 @@ struct
           let rec_args =
             ListUtil.map3
               (fun (_, spec) -> equate_boundary_value env (dlbl, desc) spec)
-              constr.rec_specs
+              (Desc.rec_specs constr)
               info0.rec_args
               info1.rec_args
           in

--- a/src/core/Quote.mli
+++ b/src/core/Quote.mli
@@ -38,14 +38,6 @@ sig
 
   val approx_restriction : env -> value -> value -> val_sys -> val_sys -> unit
 
-  val equiv_boundary_value
-    : env
-    -> Desc.data_label
-    -> Tm.data_desc
-    -> Tm.tm Desc.rec_spec
-    -> value
-    -> value
-    -> unit
 end
 
 module M (V : Val.S) : S

--- a/src/core/Typing.ml
+++ b/src/core/Typing.ml
@@ -368,7 +368,7 @@ and check_constr cx dlbl constr tms =
       go cx' const_specs rec_specs dim_specs tms
     | _ -> failwith "constructor arguments malformed"
   in
-  go cx constr.const_specs constr.rec_specs constr.dim_specs tms
+  go cx (Desc.const_specs constr) (Desc.rec_specs constr) (Desc.dim_specs constr) tms
 
 and cofibration_of_sys : type a. cx -> (Tm.tm, a) Tm.system -> cofibration =
   fun cx sys ->
@@ -619,7 +619,7 @@ and infer_spine cx hd =
         in
         (* Need to extend the context once for each constr.params, and then twice for
            each constr.args (twice, because of i.h.). *)
-        let cx', benv, nms, cvs, rvs, ihvs, rs = build_cx cx V.empty_env V.empty_env (Emp, Emp, Emp, Emp, Emp) constr.const_specs constr.rec_specs constr.dim_specs in
+        let cx', benv, nms, cvs, rvs, ihvs, rs = build_cx cx V.empty_env V.empty_env (Emp, Emp, Emp, Emp, Emp) (Desc.const_specs constr) (Desc.rec_specs constr) (Desc.dim_specs constr) in
         let intro = V.make_intro (D.Env.clear_locals @@ Cx.env cx) ~dlbl:info.dlbl ~clbl:lbl ~const_args:cvs ~rec_args:rvs ~rs in
         let ty = V.inst_clo mot_clo intro in
 
@@ -627,8 +627,8 @@ and infer_spine cx hd =
           match Tm.unleash tm with
           | Tm.Intro (dlbl, clbl, args) ->
             let constr = Desc.lookup_constr clbl desc in
-            let const_args, args = ListUtil.split (List.length constr.const_specs) args in
-            let rec_args, rs = ListUtil.split (List.length constr.rec_specs) args in
+            let const_args, args = ListUtil.split (List.length @@ Desc.const_specs constr) args in
+            let rec_args, rs = ListUtil.split (List.length @@ Desc.rec_specs constr) args in
             let nclo : D.nclo = D.NClo.act phi @@ snd @@ List.find (fun (clbl', _) -> clbl' = clbl) nclos in
             let rargs =
               List.flatten @@

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -569,7 +569,7 @@ struct
     let r, r' = Dir.unleash dir in
 
     let make_const_args dir =
-      multi_coe empty_env dir (x, constr.const_specs) const_args
+      multi_coe empty_env dir (x, Desc.const_specs constr) const_args
     in
 
     let coe_rec_arg dir _arg_spec arg =
@@ -578,7 +578,7 @@ struct
       make_coe dir abs arg
     in
 
-    let make_rec_args dir = List.map2 (coe_rec_arg dir) constr.rec_specs rec_args in
+    let make_rec_args dir = List.map2 (coe_rec_arg dir) (Desc.rec_specs constr) rec_args in
     let intro =
       make_intro empty_env ~dlbl ~clbl
         ~const_args:(make_const_args (`Ok dir))
@@ -1008,8 +1008,10 @@ struct
       let desc = Sig.lookup_datatype dlbl in
       let constr = Desc.lookup_constr info.clbl desc in
 
-      let args' = make_args 0 Emp info.const_args info.rec_args constr.const_specs constr.rec_specs in
-      let const_args, rec_args = ListUtil.split (List.length constr.const_specs) args' in
+      let const_specs = Desc.const_specs constr in
+
+      let args' = make_args 0 Emp info.const_args info.rec_args const_specs (Desc.rec_specs constr) in
+      let const_args, rec_args = ListUtil.split (List.length const_specs) args' in
 
       make @@ Intro {dlbl; clbl = info.clbl; const_args; rec_args; rs = []; sys = []}
 
@@ -1444,8 +1446,8 @@ struct
     | Tm.Intro (dlbl, clbl, args) ->
       let desc = Sig.lookup_datatype dlbl in
       let constr = Desc.lookup_constr clbl desc in
-      let tconst_args, args = ListUtil.split (List.length constr.const_specs) args in
-      let trec_args, trs = ListUtil.split (List.length constr.rec_specs) args in
+      let tconst_args, args = ListUtil.split (List.length @@ Desc.const_specs constr) args in
+      let trec_args, trs = ListUtil.split (List.length @@ Desc.rec_specs constr) args in
       let const_args = List.map (eval rho) tconst_args in
       let rec_args = List.map (eval rho) trec_args in
       let rs = List.map (eval_dim rho) trs in

--- a/src/frontend/ESig.ml
+++ b/src/frontend/ESig.ml
@@ -7,11 +7,23 @@ type 'a info =
 
 type edecl =
   | Define of string * [ `Opaque | `Transparent ] * escheme * eterm
-  | Data of string * eterm Desc.desc
+  | Data of string * edesc
   | Debug of [ `All | `Constraints | `Unsolved ]
   | Normalize of eterm
   | Import of string
   | Quit
+
+
+and edesc =
+    EDesc of
+      {kind : Kind.t;
+       lvl : Lvl.t;
+       constrs : (string * econstr) list}
+
+and econstr =
+    EConstr of
+      {specs : ecell list;
+       boundary : esys}
 
 and escheme =
   etele * eterm

--- a/src/frontend/Refiner.ml
+++ b/src/frontend/Refiner.ml
@@ -277,9 +277,9 @@ let tac_elim ~loc ~tac_mot ~tac_scrut ~clauses : chk_tac =
         | _ ->
           let constr = Desc.lookup_constr lbl desc in
           let pbinds =
-            List.map (fun (nm, _) -> ESig.PVar nm) constr.const_specs
-            @ List.mapi (fun i _ -> let x = "x" ^ string_of_int i in ESig.PIndVar (x, x ^ "/ih")) constr.rec_specs
-            @ List.map (fun x -> ESig.PVar x) constr.dim_specs
+            List.map (fun (nm, _) -> ESig.PVar nm) (Desc.const_specs constr)
+            @ List.mapi (fun i _ -> let x = "x" ^ string_of_int i in ESig.PIndVar (x, x ^ "/ih")) (Desc.rec_specs constr)
+            @ List.map (fun x -> ESig.PVar x) (Desc.dim_specs constr)
           in
           lbl, pbinds, fun goal ->
             M.lift C.ask >>= fun psi ->
@@ -348,7 +348,7 @@ let tac_elim ~loc ~tac_mot ~tac_scrut ~clauses : chk_tac =
           failwith "refine_clause"
       in
 
-      let psi, benv, tms, const_args, rec_args, ihs, rs = go Emp V.empty_env V.empty_env (Emp, Emp, Emp, Emp, Emp) pbinds constr.const_specs constr.rec_specs constr.dim_specs in
+      let psi, benv, tms, const_args, rec_args, ihs, rs = go Emp V.empty_env V.empty_env (Emp, Emp, Emp, Emp, Emp) pbinds (Desc.const_specs constr) (Desc.rec_specs constr) (Desc.dim_specs constr) in
 
       let intro = Tm.make @@ Tm.Intro (dlbl, clbl, tms) in
       let clause_ty = mot intro in
@@ -364,8 +364,8 @@ let tac_elim ~loc ~tac_mot ~tac_scrut ~clauses : chk_tac =
           match Tm.unleash tm with
           | Tm.Intro (dlbl, clbl, args) ->
             let constr = Desc.lookup_constr clbl desc in
-            let const_args, args = ListUtil.split (List.length constr.const_specs) args in
-            let rec_args, rs = ListUtil.split (List.length constr.rec_specs) args in
+            let const_args, args = ListUtil.split (List.length @@ Desc.const_specs constr) args in
+            let rec_args, rs = ListUtil.split (List.length @@ Desc.rec_specs constr) args in
             let nbnd : ty Tm.nbnd = snd @@ List.find (fun (clbl', _) -> clbl' = clbl) earlier_clauses in
             let nclo = D.NClo {nbnd; rho = Cx.env cx} in
             let cargs = List.map (fun t -> `Val (V.eval benv t)) const_args in


### PR DESCRIPTION
This is yet another intermediate stage / compromise. Now HIT constructor arguments can appear in any order, but they are processed in the rigid order (and even must appear in the rigid order in constructors and eliminators!). The next step is to process them as-written.