### PR TITLE
Debug mode

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -14,10 +14,14 @@ let opt_file_name =
       & info [] ~doc:"The name of the file being loaded" ~docv:"FILE"
     )
 
+let opt_debug =
+  let doc = "Execute in debug mode" in
+  Arg.(value & flag & info ["d"; "debug"] ~doc)
+
 let opts_config =
   let open Term  in
-  let make file_name line_width = Frontend.{file_name; line_width} in
-  pure make $ opt_file_name $ opt_margin
+  let make file_name line_width debug_mode = Frontend.{file_name; line_width; debug_mode } in
+  pure make $ opt_file_name $ opt_margin $ opt_debug
 
 let cmd_default =
   Term.

--- a/src/core/Name.ml
+++ b/src/core/Name.ml
@@ -1,3 +1,5 @@
+let debug_mode_flag = ref false
+
 let counter = ref 0
 let names = Hashtbl.create 1000
 
@@ -28,6 +30,14 @@ let to_string i =
 let pp fmt i =
   match Hashtbl.find names i with
   | Some x ->
-    Format.fprintf fmt "%a%s%i" Uuseg_string.pp_utf_8 x "%" i
+    begin
+      Uuseg_string.pp_utf_8 fmt x;
+      if !debug_mode_flag then
+        Format.fprintf fmt "%s%i" "%" i
+    end
   | None ->
     Format.fprintf fmt "%s%i" "%" i
+
+
+let set_debug_mode b =
+  debug_mode_flag := b

--- a/src/core/Name.mli
+++ b/src/core/Name.mli
@@ -1,5 +1,7 @@
 include Map.OrderedType
 
+val set_debug_mode : bool -> unit
+
 val named : string option -> t
 val fresh : unit -> t
 

--- a/src/frontend/Frontend.ml
+++ b/src/frontend/Frontend.ml
@@ -3,7 +3,8 @@ open Lexing
 
 type options =
   {file_name : Lwt_io.file_name;
-   line_width: int}
+   line_width: int;
+   debug_mode: bool}
 
 let print_position outx lexbuf =
   let pos = lexbuf.lex_curr_p in
@@ -55,14 +56,18 @@ let execute_signature dirname esig =
       exit 1
   end
 
-let load_file options =
+let set_options options =
   Format.set_margin options.line_width;
+  Name.set_debug_mode options.debug_mode
+
+let load_file options =
+  set_options options;
   let open Lwt.Infix in
   let dirname = Filename.dirname options.file_name in
   read_file options.file_name >>= execute_signature dirname
 
 let load_from_stdin options  =
-  Format.set_margin options.line_width;
+  set_options options;
   let open Lwt.Infix in
   let dirname = Filename.dirname options.file_name in
   read_from_channel options.file_name Lwt_io.stdin

--- a/src/frontend/Frontend.mli
+++ b/src/frontend/Frontend.mli
@@ -1,6 +1,7 @@
 type options =
   {file_name : Lwt_io.file_name;
-   line_width: int}
+   line_width: int;
+   debug_mode: bool}
 
 val load_file : options -> unit Lwt.t
 val load_from_stdin : options -> unit Lwt.t

--- a/vim/ftplugin/redtt.vim
+++ b/vim/ftplugin/redtt.vim
@@ -11,6 +11,10 @@ if (!exists('g:redtt_path'))
   let g:redtt_path = 'redtt'
 endif
 
+if (!exists('g:redtt_options'))
+  let g:redtt_options = ''
+endif
+
 command! Redtt :call CheckBuffer()
 nnoremap <buffer> <LocalLeader>l :call CheckBuffer()<CR>
 nnoremap <buffer> <LocalLeader>p :call CheckBufferToCursor()<CR>
@@ -33,6 +37,7 @@ function! CheckBuffer(...)
 
   let s:job = job_start(g:redtt_path .
     \' from-stdin ' . bufname('%') .
+    \' ' . g:redtt_options .
     \' --line-width ' . s:EditWidth(), {
     \'in_io': 'buffer', 'in_buf': bufnr('%'),
     \'in_bot': exists('a:1') ? a:1 : line('$'),


### PR DESCRIPTION
This changes redtt to not print out the age of variables by default, but adds a debug mode which will do so.  The debug mode is activated using `-d` or `--debug`; in Vim, this can be achieved by `let g:redtt_options = '-d'`.