### PR TITLE
[vim] turn the install script into a script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,18 @@ and [cubicaltt](https://github.com/mortberg/cubicaltt).
 
 - experimental support for Fitch-style modal guarded recursion: ▷
 
+- RedML, a (very) rudimentary tactic language
+
 
 Features we intend to add in the near future:
 
-- user-extensible tactic language
-
 - namespacing
+
+- indexed higher inductive types
+
+- a type system for RedML
+
+- algebraic effects and handlers for RedML
 
 
 

--- a/vim/README.md
+++ b/vim/README.md
@@ -14,9 +14,7 @@ buffer, ignoring lines below the cursor's current position.
 This plugin is compatible with Vim 8's package system. You can (re)install it by
 running the following shell command from the current directory:
 
-    DEST=~/.vim/pack/redprl-org/start ;
-    [ -d $DEST/vim-redtt ] && rm -r $DEST/vim-redtt ;
-    mkdir -p $DEST && cp -r . $DEST/vim-redtt
+    ./install.sh
 
 If `redtt` is not in your `PATH`, add the following line to your `.vimrc`:
 

--- a/vim/README.md
+++ b/vim/README.md
@@ -14,7 +14,6 @@ buffer, ignoring lines below the cursor's current position.
 This plugin is compatible with Vim 8's package system. You can (re)install it by
 running the following shell command from the current directory:
 
-    chmod +x install.sh
     ./install.sh
 
 If the `redtt` binary is not in your `PATH`, add the following line to your

--- a/vim/README.md
+++ b/vim/README.md
@@ -16,6 +16,7 @@ running the following shell command from the current directory:
 
     ./install.sh
 
-If `redtt` is not in your `PATH`, add the following line to your `.vimrc`:
+If the `redtt` binary is not in your `PATH`, add the following line to your
+`.vimrc`:
 
-    let g:redtt_path = '/path/to/redtt'
+    let g:redtt_path = '/path/to/the-redtt-binary'

--- a/vim/README.md
+++ b/vim/README.md
@@ -14,6 +14,7 @@ buffer, ignoring lines below the cursor's current position.
 This plugin is compatible with Vim 8's package system. You can (re)install it by
 running the following shell command from the current directory:
 
+    chmod +x install.sh
     ./install.sh
 
 If the `redtt` binary is not in your `PATH`, add the following line to your

--- a/vim/install.sh
+++ b/vim/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DEST=~/.vim/pack/redprl-org/start ;
+[ -d $DEST/vim-redtt ] && rm -r $DEST/vim-redtt ;
+mkdir -p $DEST && cp -r . $DEST/vim-redtt


### PR DESCRIPTION
The reason is, this will definitively prevent people from running this command from the wrong directory. So far everyone who has ever used the instructions (including me!) has first done so in the wrong directory, and copied a bunch of junk into their folder.