### PR TITLE
Use names instead of strings to look up a datatype.

### DIFF
--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -70,7 +70,7 @@ and pp_con fmt : con -> unit =
     let r, r' = Dir.unleash info.dir in
     Format.fprintf fmt "@[<1>(box %a %a@ %a@ %a)@]" I.pp r I.pp r' pp_value info.cap pp_val_sys info.sys
   | Data info ->
-    Uuseg_string.pp_utf_8 fmt info.lbl
+    Name.pp fmt info.lbl
   | Intro info ->
     Format.fprintf fmt "@[<hv1>(%a %a)@]"
       Uuseg_string.pp_utf_8 info.clbl
@@ -197,7 +197,7 @@ and pp_neu fmt neu =
 
   | Elim info ->
     Format.fprintf fmt "@[<hv1>(%a.elim@ %a)@]"
-      Uuseg_string.pp_utf_8 info.dlbl
+      Name.pp info.dlbl
       (* pp_clo info.mot *)
       pp_neu info.neu
   (* pp_elim_clauses info.clauses *)

--- a/src/core/DomainData.ml
+++ b/src/core/DomainData.ml
@@ -32,10 +32,10 @@ type con =
 
   | Up of {ty : value; neu : neu; sys : rigid_val_sys}
 
-  | Data of {lbl : string; params : env_el list}
+  | Data of {lbl : Name.t; params : env_el list}
 
   | Intro of
-      {dlbl : string;
+      {dlbl : Name.t;
        clbl : string;
        args : env_el list;
        sys : rigid_val_sys}
@@ -57,7 +57,7 @@ and neu =
   | Snd of neu
 
   | Elim of
-      {dlbl : string;
+      {dlbl : Name.t;
        params : env_el list;
        mot : clo;
        neu : neu;

--- a/src/core/GlobalEnv.ml
+++ b/src/core/GlobalEnv.ml
@@ -36,7 +36,7 @@ let lookup_datatype dlbl sg =
   match T.find dlbl sg.table with
   | `Data desc -> desc
   | _ ->
-    Format.eprintf "Name %a does not refer to a datatype.@." Name.pp dlbl;
+    Format.eprintf "The name %a does not refer to a datatype.@." Name.pp dlbl;
     raise Not_found
   | exception Not_found ->
     Format.eprintf "Datatype not found: %a.@." Name.pp dlbl;

--- a/src/core/GlobalEnv.mli
+++ b/src/core/GlobalEnv.mli
@@ -8,6 +8,7 @@ type entry =
   | `Def of ty * tm
   | `Tw of ty * ty
   | `I
+  | `Data of Desc.desc
   ]
 
 val emp : unit -> t
@@ -18,9 +19,9 @@ val ext_dim : t -> Name.t -> t
 val restrict : Tm.tm -> Tm.tm -> t -> t
 
 
-val declare_datatype : string -> Desc.desc -> t -> t
-val replace_datatype : string -> Desc.desc -> t -> t (* [Not_found] if the datatype is not there *)
-val lookup_datatype : string -> t ->Desc.desc
+val declare_datatype : Name.t -> Desc.desc -> t -> t
+val replace_datatype : Name.t -> Desc.desc -> t -> t (* [Not_found] if the datatype is not there *)
+val lookup_datatype : Name.t -> t -> Desc.desc
 
 module T : module type of (Map.Make (Name))
 

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -67,15 +67,15 @@ sig
   val quote_neu : env -> neu -> Tm.tm Tm.cmd
   val quote_ty : env -> value -> Tm.tm
   val quote_val_sys : env -> value -> val_sys -> (Tm.tm, Tm.tm) Tm.system
-  val equate_data_params : env -> string -> Desc.body -> env_el list -> env_el list -> Tm.tm list
-  val quote_data_params : env -> string -> Desc.body -> env_el list -> Tm.tm list
+  val equate_data_params : env -> Name.t -> Desc.body -> env_el list -> env_el list -> Tm.tm list
+  val quote_data_params : env -> Name.t -> Desc.body -> env_el list -> Tm.tm list
 
   val quote_dim : env -> I.t -> Tm.tm
 
   val equiv : env -> ty:value -> value -> value -> unit
   val equiv_ty : env -> value -> value -> unit
   val equiv_dim : env -> I.t -> I.t -> unit
-  val equiv_data_params : env -> string -> Desc.body -> env_el list -> env_el list -> unit
+  val equiv_data_params : env -> Name.t -> Desc.body -> env_el list -> env_el list -> unit
   val subtype : env -> value -> value -> unit
 
   val approx_restriction : env -> value -> value -> val_sys -> val_sys -> unit
@@ -86,7 +86,7 @@ end
 type error =
   | UnequalNf of {env : Env.t; ty : value; el0 : value; el1 : value}
   | UnequalNeu of {env : Env.t; neu0 : neu; neu1 : neu}
-  | UnequalLbl of string * string
+  | UnequalLbl of Name.t * Name.t
   | UnequalDim of I.t * I.t
 
 let pp_error fmt =
@@ -105,9 +105,9 @@ let pp_error fmt =
 
   | UnequalLbl (lbl0, lbl1) ->
     Format.fprintf fmt "@[<hv>%a@ %a@ %a@]"
-      Uuseg_string.pp_utf_8 lbl0
+      Name.pp lbl0
       Uuseg_string.pp_utf_8 "≠"
-      Uuseg_string.pp_utf_8 lbl1
+      Name.pp lbl1
 
   | UnequalDim (r0, r1) ->
     Format.fprintf fmt "@[<hv>Dimensions@ %a@ %a@ %a@]"

--- a/src/core/Quote.mli
+++ b/src/core/Quote.mli
@@ -29,15 +29,15 @@ sig
   val quote_neu : env -> neu -> Tm.tm Tm.cmd
   val quote_ty : env -> value -> Tm.tm
   val quote_val_sys : env -> value -> val_sys -> (Tm.tm, Tm.tm) Tm.system
-  val equate_data_params : env -> string -> Desc.body -> env_el list -> env_el list -> Tm.tm list
-  val quote_data_params : env -> string -> Desc.body -> env_el list -> Tm.tm list
+  val equate_data_params : env -> Name.t -> Desc.body -> env_el list -> env_el list -> Tm.tm list
+  val quote_data_params : env -> Name.t -> Desc.body -> env_el list -> Tm.tm list
 
   val quote_dim : env -> I.t -> Tm.tm
 
   val equiv : env -> ty:value -> value -> value -> unit
   val equiv_ty : env -> value -> value -> unit
   val equiv_dim : env -> I.t -> I.t -> unit
-  val equiv_data_params : env -> string -> Desc.body -> env_el list -> env_el list -> unit
+  val equiv_data_params : env -> Name.t -> Desc.body -> env_el list -> env_el list -> unit
   val subtype : env -> value -> value -> unit
 
   val approx_restriction : env -> value -> value -> val_sys -> val_sys -> unit

--- a/src/core/Tm.ml
+++ b/src/core/Tm.ml
@@ -858,10 +858,10 @@ let rec pp env fmt =
       begin
         match params with
         | [] ->
-          Uuseg_string.pp_utf_8 fmt lbl
+          Name.pp fmt lbl
         | _ ->
           Format.fprintf fmt "@[<hv1>(%a %a)@]"
-            Uuseg_string.pp_utf_8 lbl
+            Name.pp lbl
             (pp_terms env) params
       end
 
@@ -950,7 +950,7 @@ and pp_cmd env fmt (hd, sp) =
         let x_mot, env_mot = Pp.Env.bind env nm_mot in
         (* TODO *)
         Format.fprintf fmt "@[<hv1>(%a.elim@ [%a] %a@ %a@ %a)@]"
-          Uuseg_string.pp_utf_8 info.dlbl
+          Name.pp info.dlbl
           Uuseg_string.pp_utf_8 x_mot
           (pp env_mot) mot
           (go `Elim) sp
@@ -1019,7 +1019,7 @@ and pp_frame env fmt =
     Format.fprintf fmt "restrict-force"
   | Elim info ->
     Format.fprintf fmt "@[<hv1>(%a.elim@ %a@ %a)@]"
-      Uuseg_string.pp_utf_8 info.dlbl
+      Name.pp info.dlbl
       (pp_bnd env) info.mot
       (pp_elim_clauses env) info.clauses
 

--- a/src/core/TmData.ml
+++ b/src/core/TmData.ml
@@ -35,8 +35,8 @@ type 'a tmf =
   | Up of 'a cmd
   | Let of 'a cmd * 'a bnd
 
-  | Data of {lbl : string; params : 'a list}
-  | Intro of string * string * 'a list * 'a list (* TODO: turn this into inline record *)
+  | Data of {lbl : Name.t; params : 'a list}
+  | Intro of Name.t * string * 'a list * 'a list (* TODO: turn this into inline record *)
 
 
 and 'a head =
@@ -61,7 +61,7 @@ and 'a frame =
   | Cap of {r : 'a; r' : 'a; ty : 'a; sys : ('a, 'a bnd) system}
   | RestrictForce
 
-  | Elim of {dlbl : string; params : 'a list; mot : 'a bnd; clauses : (string * 'a nbnd) list}
+  | Elim of {dlbl : Name.t; params : 'a list; mot : 'a bnd; clauses : (string * 'a nbnd) list}
 
 and 'a spine = 'a frame list
 and 'a cmd = 'a head * 'a spine

--- a/src/core/Val.ml
+++ b/src/core/Val.ml
@@ -1281,7 +1281,7 @@ struct
       let mot = clo info.mot rho in
       let clauses = List.map (fun (lbl, nbnd) -> lbl, nclo nbnd rho) info.clauses in
       let params = List.map (fun tm -> `Val (eval rho tm)) info.params in
-      elim_data info.dlbl ~params ~mot ~scrut:vhd ~clauses
+      elim_data ~dlbl:info.dlbl ~params ~mot ~scrut:vhd ~clauses
 
 
   and eval_head rho =
@@ -1697,7 +1697,7 @@ struct
       let err = RigidVProjUnexpectedArgument (x, el) in
       raise @@ E err
 
-  and elim_data dlbl ~params ~mot ~scrut ~clauses =
+  and elim_data ~dlbl ~params ~mot ~scrut ~clauses =
     let find_clause clbl =
       try
         snd @@ List.find (fun (clbl', _) -> clbl = clbl') clauses
@@ -1719,7 +1719,7 @@ struct
           cell :: go args specs
         | `Val v :: args, (_, `Rec Desc.Self) :: specs ->
           (* What do I do here if not Desc.Self??? *)
-          let v_ih = elim_data dlbl ~params ~mot ~scrut:v ~clauses in
+          let v_ih = elim_data ~dlbl ~params ~mot ~scrut:v ~clauses in
           `Val v :: `Val v_ih :: go args specs
         | cell :: args, (_, `Dim) :: specs ->
           cell :: go args specs
@@ -1738,7 +1738,7 @@ struct
         Face.map @@ fun r r' a ->
         let phi = I.equate r r' in
         let clauses' = List.map (fun (lbl, nclo) -> lbl, NClo.act phi nclo) clauses in
-        elim_data dlbl ~params ~mot:(Clo.act phi mot) ~scrut:a ~clauses:clauses'
+        elim_data ~dlbl ~params ~mot:(Clo.act phi mot) ~scrut:a ~clauses:clauses'
       in
       let elim_sys = List.map elim_face up.sys in
       make @@ Up {ty = mot'; neu; sys = elim_sys}
@@ -1750,7 +1750,7 @@ struct
         inst_clo mot @@
         make_fhcom (Dir.make r @@ `Atom y) info.cap (`Ok info.sys)
       in
-      let cap = elim_data dlbl ~params ~mot ~scrut:info.cap ~clauses in
+      let cap = elim_data ~dlbl ~params ~mot ~scrut:info.cap ~clauses in
       let face =
         Face.map @@ fun r r' abs ->
         let y, ely = Abs.unleash1 abs in
@@ -1758,7 +1758,7 @@ struct
         let clauses' = List.map (fun (lbl, nclo) -> lbl, NClo.act phi nclo) clauses in
         let params' = List.map (Env.act_env_el phi) params in
         Abs.bind1 y @@
-        elim_data dlbl ~params:params' ~mot:(Clo.act phi mot) ~scrut:ely ~clauses:clauses'
+        elim_data ~dlbl ~params:params' ~mot:(Clo.act phi mot) ~scrut:ely ~clauses:clauses'
       in
       let sys = List.map face info.sys in
       rigid_com info.dir tyabs cap sys

--- a/src/core/ValSig.ml
+++ b/src/core/ValSig.ml
@@ -9,7 +9,7 @@ sig
   (** Return the type and definition of a global variable *)
   val lookup : Name.t -> Tm.twin -> Tm.tm * Tm.tm option
 
-  val lookup_datatype : string -> Desc.desc
+  val lookup_datatype : Name.t -> Desc.desc
 end
 
 exception MissingElimClause of string
@@ -53,11 +53,11 @@ sig
   val unleash_restriction_ty : value -> val_face
 
 
-  val realize_rec_spec : dlbl:string -> params:env_el list -> Desc.rec_spec -> value
-  val realize_rec_spec_ih : dlbl:string -> params:env_el list -> mot:clo -> Desc.rec_spec -> value -> value
+  val realize_rec_spec : dlbl:Name.t -> params:env_el list -> Desc.rec_spec -> value
+  val realize_rec_spec_ih : dlbl:Name.t -> params:env_el list -> mot:clo -> Desc.rec_spec -> value -> value
 
-  val elim_data : string -> params:env_el list -> mot:clo -> scrut:value -> clauses:(string * nclo) list -> value
-  val make_intro : dlbl:string -> params:env_el list -> clbl:string -> env_el list -> value
+  val elim_data : dlbl:Name.t -> params:env_el list -> mot:clo -> scrut:value -> clauses:(string * nclo) list -> value
+  val make_intro : dlbl:Name.t -> params:env_el list -> clbl:string -> env_el list -> value
 
   module Sig : Sig
 

--- a/src/frontend/Contextual.ml
+++ b/src/frontend/Contextual.ml
@@ -149,23 +149,13 @@ let update_env e =
      per_process =
        {env = GlobalEnv.define st.per_process.env nm ty t;
         info = Map.add nm `Rigid st.per_process.info};
-     resenv =
-       begin
-         match Name.name nm with
-         | Some str -> ResEnv.named_metavar ~visibility str nm st.resenv
-         | None -> st.resenv
-       end}
+     resenv = ResEnv.register_metavar ~visibility nm st.resenv}
   | E (nm, ty, Defn (visibility, `Opaque, _)) ->
     {st with
      per_process =
        {env = GlobalEnv.ext_meta st.per_process.env nm @@ `P ty;
         info = Map.add nm `Rigid st.per_process.info};
-     resenv =
-       begin
-         match Name.name nm with
-         | Some str -> ResEnv.named_metavar ~visibility str nm st.resenv
-         | None -> st.resenv
-       end}
+     resenv = ResEnv.register_metavar ~visibility nm st.resenv}
   | _ ->
     st
 
@@ -174,8 +164,7 @@ let declare_datatype visibility dlbl desc =
   {st with
    per_process =
      {st.per_process with env = GlobalEnv.declare_datatype dlbl desc st.per_process.env};
-   resenv = ResEnv.datatype visibility dlbl st.resenv
-  }
+   resenv = ResEnv.register_datatype visibility dlbl st.resenv}
 
 let replace_datatype dlbl desc =
   modify @@ fun st ->
@@ -252,13 +241,7 @@ let resolver =
     | Emp -> renv
     | Snoc (psi, (x, _)) ->
       let renv = go_locals renv psi in
-      begin
-        match Name.name x with
-        | Some str ->
-          ResEnv.named_var `Private str x renv
-        | None ->
-          renv
-      end
+      ResEnv.register_var `Private x renv
   in
 
   get >>= fun st ->

--- a/src/frontend/Contextual.mli
+++ b/src/frontend/Contextual.mli
@@ -20,8 +20,8 @@ val get_mlenv : ML.mlenv m
 
 val resolver : ResEnv.t m
 val modify_top_resolver : (ResEnv.t -> ResEnv.t) -> unit m
-val declare_datatype : ResEnv.visibility -> string -> Desc.desc -> unit m
-val replace_datatype : string -> Desc.desc -> unit m
+val declare_datatype : ResEnv.visibility -> Name.t -> Desc.desc -> unit m
+val replace_datatype : Name.t -> Desc.desc -> unit m
 
 val isolate : 'a m -> 'a m
 

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -59,7 +59,7 @@ struct
               C.get_global_env >>= fun env ->
               begin
                 match GlobalEnv.lookup env alpha with
-                | (`P _ | `Tw _ | `Def _) -> M.ret @@ `FunApp e
+                | (`P _ | `Tw _ | `Def _ | `Data _) -> M.ret @@ `FunApp e
                 | `I -> M.ret @@ `ExtApp e
               end
             | _ ->
@@ -160,8 +160,9 @@ struct
       end
 
     | E.MlDeclData info ->
-      elab_datatype info.visibility info.name info.desc >>= fun desc ->
-      C.replace_datatype info.name desc >>
+      eval_val info.name <<@> E.unleash_ref >>= fun alpha ->
+      elab_datatype info.visibility alpha info.desc >>= fun desc ->
+      C.replace_datatype alpha desc >>
       M.ret @@ E.SemRet (E.SemDataDesc desc)
 
     | E.MlImport (visibility, selector) ->
@@ -292,9 +293,10 @@ struct
           Desc.TNil boundary
 
       | `Ty (nm, ety) :: args ->
+        C.resolver >>= fun renv ->
         begin
           match E.(ety.con) with
-          | E.Var var when var.name = dlbl ->
+          | E.Var var when ResEnv.get var.name renv = `Datatype dlbl ->
             let x = Name.named @@ Some nm in
             M.in_scope x (`P data_ty) (go args) <<@> fun constr ->
               Desc.TCons (`Rec Desc.Self, Desc.Constr.bind x constr)

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -587,14 +587,24 @@ tm:
       Tm.Cons (e0 env, e1 env) }
 
   | LPR; DATA; dlbl = ATOM; RPR
-    { fun _ ->
+    { fun env ->
       make_node $startpos $endpos @@
-      Tm.Data {lbl = Name.named (Some dlbl); params = []} }
+      match R.get dlbl env with
+      | `Datatype alpha ->
+        Tm.Data {lbl = alpha; params = []}
+      | _ ->
+        Format.eprintf "The name %s does not refer to a datatype.@." dlbl;
+        raise Not_found }
 
   | LPR; dlbl = ATOM; DOT; INTRO; clbl = ATOM; es = elist(tm); RPR
     { fun env ->
       make_node $startpos $endpos @@
-      Tm.Intro (Name.named (Some dlbl), clbl, [], es env) }
+      match R.get dlbl env with
+      | `Datatype alpha ->
+        Tm.Intro (alpha, clbl, [], es env)
+      | _ ->
+        Format.eprintf "The name %s does not refer to a datatype.@." dlbl;
+        raise Not_found }
 
   | e = cmd
     { fun env ->

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -358,8 +358,9 @@ mltoplevel:
       {rest with con = MlBind (E.define ~visibility ~name ~opacity ~scheme:sch ~tm, `User a, rest.con)} }
 
   | visibility = data_modifiers; decl = data_decl; rest = mltoplevel
-    { let name, desc = decl in
-      {rest with con = MlBind (E.MlDeclData {visibility; name; desc}, `User name, rest.con)} }
+    { let a, desc = decl in
+      let name = E.MlRef (Name.named (Some a)) in
+      {rest with con = MlBind (E.MlDeclData {visibility; name; desc}, `User a, rest.con)} }
 
   | path = IMPORT; rest = mltoplevel
     { {rest with con = E.mlbind (E.MlImport (`Private, path)) @@ fun _ -> rest.con} }
@@ -417,7 +418,8 @@ atomic_mlcmd:
 
   | LLGL; visibility = data_modifiers; decl = data_decl; RRGL
     { let name, desc = decl in
-    E.MlDeclData {visibility; name; desc} }
+      let name = E.MlRef (Name.named (Some name)) in
+      E.MlDeclData {visibility; name; desc} }
 
   | LLGL; modifiers = def_modifiers; DEF; a = ATOM; sch = escheme; EQUALS; tm = located(econ); RRGL
     { let name = E.MlRef (Name.named (Some a)) in
@@ -587,12 +589,12 @@ tm:
   | LPR; DATA; dlbl = ATOM; RPR
     { fun _ ->
       make_node $startpos $endpos @@
-      Tm.Data {lbl = dlbl; params = []} }
+      Tm.Data {lbl = Name.named (Some dlbl); params = []} }
 
   | LPR; dlbl = ATOM; DOT; INTRO; clbl = ATOM; es = elist(tm); RPR
     { fun env ->
       make_node $startpos $endpos @@
-      Tm.Intro (dlbl, clbl, [], es env) }
+      Tm.Intro (Name.named (Some dlbl), clbl, [], es env) }
 
   | e = cmd
     { fun env ->

--- a/src/frontend/ML.ml
+++ b/src/frontend/ML.ml
@@ -29,7 +29,7 @@ and mlcmd =
   | MlElab of eterm
   | MlElabWithScheme of escheme * eterm
   | MlCheck of {ty : mlval; tm : mlval}
-  | MlDeclData of {visibility : ResEnv.visibility; name : string; desc : edesc}
+  | MlDeclData of {visibility : ResEnv.visibility; name : mlval; desc : edesc}
   | MlDefine of {visibility : ResEnv.visibility; name : mlval; opacity : [`Opaque | `Transparent]; ty : mlval; tm : mlval}
   | MlSplit of mlval * mlname list * mlcmd
   | MlUnify

--- a/src/frontend/ResEnv.ml
+++ b/src/frontend/ResEnv.ml
@@ -5,14 +5,14 @@ open RedTT_Core
 type global =
   [ `Var of Name.t
   | `Metavar of Name.t
-  | `Datatype of string
+  | `Datatype of Name.t
   ]
 
 type resolution =
   [ `Ix of int
   | `Var of Name.t
   | `Metavar of Name.t
-  | `Datatype of string
+  | `Datatype of Name.t
   ]
 
 type visibility =
@@ -68,18 +68,23 @@ let get x renv =
       failwith @@ "Could not resolve variable: " ^ x
 
 
-
-let named_var ~visibility s x renv =
+let set_global_ s x renv =
   {renv with
-   globals = T.set s (`Var x, visibility) renv.globals}
+   globals = T.set s x renv.globals}
 
-let named_metavar ~visibility s x renv =
-  {renv with
-   globals = T.set s (`Metavar x, visibility) renv.globals}
+let set_global nm x renv =
+  match Name.name nm with
+  | Some str -> set_global_ str x renv
+  | None -> renv
 
-let datatype ~visibility s renv =
-  {renv with
-   globals = T.set s (`Datatype s, visibility) renv.globals}
+let register_var ~visibility nm =
+  set_global nm (`Var nm, visibility)
+
+let register_metavar ~visibility nm =
+  set_global nm (`Metavar nm, visibility)
+
+let register_datatype ~visibility nm =
+  set_global nm (`Datatype nm, visibility)
 
 let import_globals ~visibility imported renv =
   {renv with

--- a/src/frontend/ResEnv.mli
+++ b/src/frontend/ResEnv.mli
@@ -1,10 +1,15 @@
 open RedTT_Core
 
+(** This module has two responsibilities:
+
+    1. maintain the mapping from strings to names.
+    2. keep track of items to be serialized. *)
+
 type resolution =
   [ `Ix of int
   | `Var of Name.t
   | `Metavar of Name.t
-  | `Datatype of string
+  | `Datatype of Name.t
   ]
 
 type visibility =
@@ -17,9 +22,9 @@ val bind : string -> t -> t
 val bindn : string list -> t -> t
 val bind_opt : string option -> t -> t
 
-val named_var : visibility:visibility -> string -> Name.t -> t -> t
-val named_metavar : visibility:visibility -> string -> Name.t -> t -> t
-val datatype : visibility:visibility -> string -> t -> t
+val register_var : visibility:visibility -> Name.t -> t -> t
+val register_metavar : visibility:visibility -> Name.t -> t -> t
+val register_datatype : visibility:visibility -> Name.t -> t -> t
 
 val import_globals : visibility:visibility -> t -> t -> t
 


### PR DESCRIPTION
@jonsterling I also change the name in ML from `string` to `mlval`.