### PR TITLE
[vim] Usability improvements.

### DIFF
--- a/src/frontend/Importer.ml
+++ b/src/frontend/Importer.ml
@@ -57,10 +57,10 @@ struct
       | Some rot -> ret rot
       | None ->
         begin
-          if !ignore_rot then ret None else begin
-            let rotpath = FileRes.stem_to_rot stem in
+          if !ignore_rot then
+            ret None
+          else
             RotIO.try_read ~redsum:None ~importer:import ~stem
-          end
         end >>= function
         | Some rot ->
           store_module stem rot >> ret rot
@@ -81,13 +81,12 @@ struct
     | TopModule {indent} ->
       let stem = FileRes.red_to_stem red in
       begin
-        if !ignore_rot then ret None else begin
-          let rotpath = FileRes.stem_to_rot stem in
+        if !ignore_rot then
+          ret None
+        else
           RotIO.try_read ~redsum:None ~importer:import ~stem
-        end
       end >>= function
       | Some rot ->
-        let rotpath = FileRes.stem_to_rot stem in
         store_module stem rot
       | None ->
         let mlcmd, redsum = read_file red in
@@ -105,7 +104,12 @@ struct
     | TopModule {indent} ->
       let stem = FileRes.red_to_stem red in
       let mlcmd, redsum = read_from_channel ~filepath:red stdin in
-      RotIO.try_read ~redsum:(Some redsum) ~importer:import ~stem >>=
+      begin
+        if !ignore_rot then
+          ret None
+        else
+          RotIO.try_read ~redsum:(Some redsum) ~importer:import ~stem
+      end >>=
       begin
         function
         | Some rot ->

--- a/vim/README.md
+++ b/vim/README.md
@@ -6,7 +6,8 @@ This vim plugin requires Vim 8 (released September 2016).
 
 While editing a .red file, run `:Redtt` or `<LocalLeader>l` (`l` for `load`) in
 the command (normal) mode to check the current buffer and display the output in
-a separate buffer. Run `<LocalLeader>p` (`p` for `partial`) to check the current
+a separate buffer. Run `<LocalLeader>L` to check the current buffer with
+`--ignore-cache`. Run `<LocalLeader>p` (`p` for `partial`) to check the current
 buffer, ignoring lines below the cursor's current position.
 
 ### Typing special characters

--- a/vim/README.md
+++ b/vim/README.md
@@ -6,9 +6,9 @@ This vim plugin requires Vim 8 (released September 2016).
 
 While editing a .red file, run `:Redtt` or `<LocalLeader>l` (`l` for `load`) in
 the command (normal) mode to check the current buffer and display the output in
-a separate buffer. Run `<LocalLeader>L` to check the current buffer with
-`--ignore-cache`. Run `<LocalLeader>p` (`p` for `partial`) to check the current
-buffer, ignoring lines below the cursor's current position.
+a separate buffer. Run `<LocalLeader>p` (`p` for `partial`) to check the current
+buffer, ignoring lines below the cursor's current position. The `<LocalLeader>L`
+and `<LocalLeader>P` commands are analogous but use the `--ignore-cache` option.
 
 ### Typing special characters
 

--- a/vim/ftplugin/redtt.vim
+++ b/vim/ftplugin/redtt.vim
@@ -19,6 +19,7 @@ command! Redtt :call CheckBuffer('')
 nnoremap <buffer> <LocalLeader>l :call CheckBuffer('')<CR>
 nnoremap <buffer> <LocalLeader>L :call CheckBuffer('--ignore-cache')<CR>
 nnoremap <buffer> <LocalLeader>p :call CheckBufferToCursor('')<CR>
+nnoremap <buffer> <LocalLeader>P :call CheckBufferToCursor('--ignore-cache')<CR>
 autocmd QuitPre <buffer> call s:CloseBuffer()
 
 digraph !- 8866

--- a/vim/ftplugin/redtt.vim
+++ b/vim/ftplugin/redtt.vim
@@ -15,9 +15,10 @@ if (!exists('g:redtt_options'))
   let g:redtt_options = ''
 endif
 
-command! Redtt :call CheckBuffer()
-nnoremap <buffer> <LocalLeader>l :call CheckBuffer()<CR>
-nnoremap <buffer> <LocalLeader>p :call CheckBufferToCursor()<CR>
+command! Redtt :call CheckBuffer('')
+nnoremap <buffer> <LocalLeader>l :call CheckBuffer('')<CR>
+nnoremap <buffer> <LocalLeader>L :call CheckBuffer('--ignore-cache')<CR>
+nnoremap <buffer> <LocalLeader>p :call CheckBufferToCursor('')<CR>
 autocmd QuitPre <buffer> call s:CloseBuffer()
 
 digraph !- 8866
@@ -26,7 +27,7 @@ digraph <: 10633
 digraph :> 10634
 
 " Optional argument: the last line to send to redtt (default: all).
-function! CheckBuffer(...)
+function! CheckBuffer(options, ...)
   if (exists('s:job'))
     call job_stop(s:job, 'int')
   endif
@@ -45,6 +46,7 @@ function! CheckBuffer(...)
 
   let s:job = job_start(g:redtt_path .
     \' from-stdin ' . l:toCheck .
+    \' ' . a:options .
     \' ' . g:redtt_options .
     \' --line-width ' . s:EditWidth(), {
     \'in_io': 'buffer', 'in_buf': bufnr('%'),
@@ -53,15 +55,15 @@ function! CheckBuffer(...)
     \'err_io': 'buffer', 'err_name': 'redtt', 'err_msg': 0})
 endfunction
 
-function! CheckBufferToCursor()
-  call CheckBuffer(line('.'))
+function! CheckBufferToCursor(options)
+  call CheckBuffer(a:options, line('.'))
 endfunction
 
 " Call this only from redtt output buffer.
-function! g:CheckFromOutputBuffer()
+function! g:CheckFromOutputBuffer(options)
   if (bufexists(b:active) && (winbufnr(bufwinnr(b:active)) == bufnr(b:active)))
     execute bufwinnr(b:active) . 'wincmd w'
-    call CheckBuffer()
+    call CheckBuffer(a:options)
   endif
 endfunction
 
@@ -69,7 +71,8 @@ function! s:InitBuffer()
   set buftype=nofile
   set syntax=redtt
   set noswapfile
-  nnoremap <buffer> <LocalLeader>l :call CheckFromOutputBuffer()<CR>
+  nnoremap <buffer> <LocalLeader>l :call CheckFromOutputBuffer('')<CR>
+  nnoremap <buffer> <LocalLeader>L :call CheckFromOutputBuffer('--ignore-cache')<CR>
 endfunction
 
 function! s:EditWidth()


### PR DESCRIPTION
This contains three improvements to the vim mode.

- `<LocalLeader>L` and `<LocalLeader>P` add the `--ignore-cache` option.
- Typing `<LocalLeader>l` or `<LocalLeader>L` in the `redtt` output buffer will recheck the most recently checked `.red` file, if it is still open. (Requested by @jonsterling)
- When closing a `.red` buffer, only close the `redtt` output buffer if the `.red` file is the most recently checked one.