### PR TITLE
proofs about HIT-style integers

### DIFF
--- a/library/basics/biinv-equiv.red
+++ b/library/basics/biinv-equiv.red
@@ -9,8 +9,8 @@ def is-biinv-equiv (A B : type) (f : A → B) : type =
 
 def biinv-equiv (A B : type) : type = (f : A → B) × is-biinv-equiv A B f
 
-def biinv-equiv→iso (A B : type) (bie : biinv-equiv A B) : iso A B =
-  let (f,(g,α),(h,β)) = bie in
+def biinv-equiv→iso (A B : type) : biinv-equiv A B → iso A B =
+  λ (f,(g,α),h,β) →
   let β' (a : A) : path _ (g (f a)) a =
     λ i →
     comp 0 1 (h (α (f a) i)) [
@@ -19,8 +19,3 @@ def biinv-equiv→iso (A B : type) (bie : biinv-equiv A B) : iso A B =
     ]
   in
   (f,g,α,β')
-
-def biinv-equiv/prop (A B : type) (f : A → B) : is-prop (is-biinv-equiv A B f) =
-  λ (s0,r0) (s1,r1) i →
-  let c = iso→equiv _ _ (biinv-equiv→iso _ _ (f,s0,r0)) .snd in
-  (equiv-section/prop A B f c s0 s1 i, equiv-retraction/prop A B f c r0 r1 i)

--- a/library/basics/biinv-equiv.red
+++ b/library/basics/biinv-equiv.red
@@ -1,0 +1,26 @@
+import prelude
+import basics.isotoequiv
+import basics.retract
+
+-- Bi-invertible map definition of equivalence
+
+def is-biinv-equiv (A B : type) (f : A → B) : type =
+  section A B f × retraction A B f
+
+def biinv-equiv (A B : type) : type = (f : A → B) × is-biinv-equiv A B f
+
+def biinv-equiv→iso (A B : type) (bie : biinv-equiv A B) : iso A B =
+  let (f,(g,α),(h,β)) = bie in
+  let β' (a : A) : path _ (g (f a)) a =
+    λ i →
+    comp 0 1 (h (α (f a) i)) [
+    | i=0 j → β (g (f a)) j
+    | i=1 j → β a j
+    ]
+  in
+  (f,g,α,β')
+
+def biinv-equiv/prop (A B : type) (f : A → B) : is-prop (is-biinv-equiv A B f) =
+  λ (s0,r0) (s1,r1) i →
+  let c = iso→equiv _ _ (biinv-equiv→iso _ _ (f,s0,r0)) .snd in
+  (equiv-section/prop A B f c s0 s1 i, equiv-retraction/prop A B f c r0 r1 i)

--- a/library/basics/ha-equiv.red
+++ b/library/basics/ha-equiv.red
@@ -1,19 +1,20 @@
 import prelude
-import basics.isotoequiv
+import basics.retract
 
 -- Half-adjoint equivalence
+
+def lcoh (A B : type) (f : A → B) (g : B → A) (f-g : (b : _) → path _ (f (g b)) b) : type =
+  (g-f : (a : _) → path _ (g (f a)) a)
+  × (a : A) → path (path _ (f (g (f a))) (f a)) (λ i → f (g-f a i)) (f-g (f a))
 
 def is-ha-equiv (A B : type) (f : A → B) : type =
   (g : B → A)
   × (f-g : (b : _) → path _ (f (g b)) b)
-  × (g-f : (a : _) → path _ (g (f a)) a)
-  × (a : A) → path (path _ (f (g (f a))) (f a)) (λ i → f (g-f a i)) (f-g (f a))
+  × lcoh A B f g f-g
 
 def ha-equiv (A B : type) : type = (f : A → B) × is-ha-equiv A B f
 
-
 -- this symmetry function is exactly involutive on all but the highest coherence
-
 def ha-equiv/symm (A B : type) (e : ha-equiv A B) : ha-equiv B A =
   let (f, g, f-g, g-f, adj) = e in
   let adj' (b : B) : path (path _ (g (f (g b))) (g b)) (λ i → g (f-g b i)) (g-f (g b)) =

--- a/library/basics/ha-equiv.red
+++ b/library/basics/ha-equiv.red
@@ -1,0 +1,66 @@
+import prelude
+import basics.isotoequiv
+
+-- Half-adjoint equivalence
+
+def is-ha-equiv (A B : type) (f : A → B) : type =
+  (g : B → A)
+  × (f-g : (b : _) → path _ (f (g b)) b)
+  × (g-f : (a : _) → path _ (g (f a)) a)
+  × (a : A) → path (path _ (f (g (f a))) (f a)) (λ i → f (g-f a i)) (f-g (f a))
+
+def ha-equiv (A B : type) : type = (f : A → B) × is-ha-equiv A B f
+
+
+-- this symmetry function is exactly involutive on all but the highest coherence
+
+def ha-equiv/symm (A B : type) (e : ha-equiv A B) : ha-equiv B A =
+  let (f, g, f-g, g-f, adj) = e in
+  let adj' (b : B) : path (path _ (g (f (g b))) (g b)) (λ i → g (f-g b i)) (g-f (g b)) =
+    λ j i →
+    let cap0 : A =
+      comp 1 0 (g (f-g (f-g b i) j)) [
+      | i=0 k → g (adj (g b) k j)
+      | i=1 | ∂[j] → refl
+      ]
+    in
+    let filler (x k : 𝕀) : A =
+      comp 0 x (g-f (g b) k) [
+      | k=0 x → g (f-g b x)
+      | k=1 → refl
+      ]
+    in
+    let cap1 : A =
+      comp 0 1 cap0 [
+      | i=0 k → g-f (g-f (g b) j) k
+      | i=1 → filler j
+      | j=0 k → g-f (g (f-g b i)) k
+      | j=1 → filler i
+      ]
+    in
+    comp 1 0 cap1 [
+    | i=0 k → weak-connection/and A (g-f (g b)) j k
+    | i=1 → refl
+    | j=0 → refl
+    | j=1 k → weak-connection/or A (g-f (g b)) i k
+    ]
+  in
+  (g, f, g-f, f-g, adj')
+
+def equiv→ha-equiv (A B : type) (e : equiv A B) : ha-equiv A B =
+  let (f, c) = e in
+  let g (b : B) = c b .fst .fst in
+  let f-g (b : B) = c b .fst .snd in
+  let p (a : A) = symm (fiber A B f (f a)) (c (f a) .snd (a, refl)) in
+  ( f
+  , g
+  , f-g
+  , λ a i → p a i .fst
+  , λ a j i →
+    comp 1 0 (p a i .snd j) [
+    | i=0 k → weak-connection/and B (f-g (f a)) j k
+    | i=1 → refl
+    | j=0 → refl
+    | j=1 k → weak-connection/or B (f-g (f a)) i k
+    ]
+  )

--- a/library/basics/isotoequiv.red
+++ b/library/basics/isotoequiv.red
@@ -10,6 +10,9 @@ def iso (A B : type) : type =
   × ((b : _) → path _ (f (g b)) b)
   × (a : _) → path _ (g (f a)) a
 
+def iso/symm (A B : type) (I : iso A B) : iso B A =
+  let (f,g,α,β) = I in (g,f,β,α)
+
 def iso/fiber/prop-over
   (A B : type)
   (I : iso A B) (b : 𝕀 → B)
@@ -56,3 +59,10 @@ def iso→equiv-over (A B : type) (I : iso A B) : equiv-over A B =
   let (f, g, α, β) = I in
   (f , (λ b → (g b, α b), λ b fib → iso/fiber/prop-over _ _ I b fib (g (b 1), α (b 1))))
 -/
+
+def equiv→iso (A B : type) (e : equiv A B) : iso A B =
+  ( e .fst
+  , λ b → e .snd b .fst .fst
+  , λ b → e .snd b .fst .snd
+  , λ a i → symm (fiber A B (e .fst) (e .fst a)) (e .snd (e .fst a) .snd (a, refl)) i .fst
+  )

--- a/library/basics/isotoequiv.red
+++ b/library/basics/isotoequiv.red
@@ -23,29 +23,29 @@ def iso/fiber/prop-over
     ]
   in
   λ fib0 fib1 →
-    let sq2 (i k : 𝕀) : A =
-      comp 0 k (g (b i)) [
-      | i=0 → sq (b 0) fib0 1
-      | i=1 → sq (b 1) fib1 1
+  let sq2 (i k : 𝕀) : A =
+    comp 0 k (g (b i)) [
+    | i=0 → sq (b 0) fib0 1
+    | i=1 → sq (b 1) fib1 1
+    ]
+  in
+  λ i →
+  ( refl
+  , λ j →
+    let aux : A =
+      comp j 0 (β (sq2 i 1) j) [
+      | j=1 → sq2 i
+      | i=0 → sq (b 0) fib0 j
+      | i=1 → sq (b 1) fib1 j
       ]
     in
-    λ i →
-    ( refl
-    , λ j →
-       let aux : A =
-         comp j 0 (β (sq2 i 1) j) [
-         | j=1 → sq2 i
-         | i=0 → sq (b 0) fib0 j
-         | i=1 → sq (b 1) fib1 j
-         ]
-       in
-       comp 0 1 (f aux) [
-       | i=0 → α (fib0.snd j)
-       | i=1 → α (fib1.snd j)
-       | j=0 → α (f (sq2 i 1))
-       | j=1 → α (b i)
-       ]
-    )
+    comp 0 1 (f aux) [
+    | i=0 → α (fib0.snd j)
+    | i=1 → α (fib1.snd j)
+    | j=0 → α (f (sq2 i 1))
+    | j=1 → α (b i)
+    ]
+  )
 
 def iso→equiv (A B : type) (I : iso A B) : equiv A B =
   let (f, g, α, β) = I in

--- a/library/basics/retract.red
+++ b/library/basics/retract.red
@@ -103,7 +103,7 @@ def path-retract/equiv (A : type) (R : A → A → type)
     , λ p → J A p (λ q → path _ (ret a (q 1) .fst (ret a (q 1) .snd .fst q)) q) preserves-refl
     , ret a b .snd .snd
     )
-  
+
 def equiv-section/prop (A B : type) (f : A → B) (c : is-equiv A B f)
   : is-prop (section A B f) =
   λ (g0,p0) (g1,p1) i →
@@ -112,3 +112,21 @@ def equiv-section/prop (A B : type) (f : A → B) (c : is-equiv A B f)
   in
   (λ b → α b i .fst, λ b → α b i .snd)
 
+-- TODO this does not really belong in this file
+def precompose-equiv (A B C : type) (e : equiv A B) : equiv (B → C) (A → C) =
+  let (f,g,α,β) = equiv→iso _ _ e in
+  iso→equiv (B → C) (A → C)
+    ( λ h a → h (f a)
+    , λ k b → k (g b)
+    , λ k i a → k (β a i)
+    , λ h i b → h (α b i)
+    )
+
+def equiv-retraction/prop (A B : type) (f : A → B) (c : is-equiv A B f)
+  : is-prop (retraction A B f) =
+  λ (g0,q0) (g1,q1) i →
+  let p =
+    contr→prop _ (precompose-equiv A B A (f,c) .snd (λ a → a))
+      (g0, λ j b → q0 b j) (g1, λ j b → q1 b j)
+  in
+  (p i .fst, λ b j → p i .snd j b)

--- a/library/basics/retract.red
+++ b/library/basics/retract.red
@@ -1,17 +1,20 @@
 import prelude
 import basics.isotoequiv
 
-def is-section (A B : type) (f : A → B) : type =
+def retraction (A B : type) (f : A → B) : type =
   (g : B → A) × (a : A) → path A (g (f a)) a
 
+def section (A B : type) (f : A → B) : type =
+  (g : B → A) × (b : B) → path B (f (g b)) b
+
 def retract (A B : type) : type =
-  (f : A → B) × is-section A B f
+  (f : A → B) × retraction A B f
 
 def retract/path-action (A B : type)
-  (f : A → B) (f/sec : is-section A B f) (a a' : A)
+  (f : A → B) (retr : retraction A B f) (a a' : A)
   : retract (path _ a a') (path B (f a) (f a'))
   =
-  let (g,α) = f/sec in
+  let (g,α) = retr in
   ( λ p i → f (p i)
   , λ q i → comp 0 1 (g (q i)) [i=0 → α a | i=1 → α a']
   , λ p j i → comp j 1 (α (p i) j) [i=0 → α a | i=1 → α a']
@@ -36,9 +39,9 @@ def retract/hlevel : (l : hlevel) (A B : type)
       | i=0 → α a
       | i=1 → α a'
       ]
-    | hsuc (l → l/ih) → λ A B (f,sec) B/level a a' →
+    | hsuc (l → l/ih) → λ A B (f,retr) B/level a a' →
       l/ih (path _ a a') (path B (f a) (f a'))
-        (retract/path-action A B f sec a a')
+        (retract/path-action A B f retr a a')
         (B/level (f a) (f a'))
     ]
   ]
@@ -101,4 +104,11 @@ def path-retract/equiv (A : type) (R : A → A → type)
     , ret a b .snd .snd
     )
   
+def equiv-section/prop (A B : type) (f : A → B) (c : is-equiv A B f)
+  : is-prop (section A B f) =
+  λ (g0,p0) (g1,p1) i →
+  let α (b : B) : path (fiber A B f b) (g0 b, p0 b) (g1 b, p1 b) =
+    contr→prop (fiber A B f b) (c b) (g0 b, p0 b) (g1 b, p1 b)
+  in
+  (λ b → α b i .fst, λ b → α b i .snd)
 

--- a/library/cool/biinv-int.red
+++ b/library/cool/biinv-int.red
@@ -1,0 +1,220 @@
+import prelude
+import data.nat
+import data.int
+import basics.isotoequiv
+import basics.ha-equiv
+import basics.retract
+
+data biinv-int where
+| zero
+| suc (z : biinv-int)
+| predl (z : biinv-int)
+| predr (z : biinv-int)
+| predl-suc (z : biinv-int) (i : 𝕀) [i=0 → predl (suc z) | i=1 → z]
+| suc-predr (z : biinv-int) (i : 𝕀) [i=0 → suc (predr z) | i=1 → z]
+
+def predl/ha-equiv : ha-equiv biinv-int biinv-int =
+  equiv→ha-equiv _ _
+    (iso→equiv biinv-int biinv-int
+      ( λ z → predl z
+      , λ z → suc z
+      , λ z i → predl-suc z i
+      , λ z i →
+        comp 0 1 (suc (predl-suc (predr z) i)) [
+        | i=0 j → suc (predl (suc-predr z j))
+        | i=1 j → suc-predr z j
+        ]
+      ))
+
+def suc-predl = predl/ha-equiv .snd .snd .snd .fst
+def predl-adj = predl/ha-equiv .snd .snd .snd .snd
+def suc-adj = ha-equiv/symm _ _ predl/ha-equiv .snd .snd .snd .snd
+
+def suc/equiv : equiv biinv-int biinv-int =
+  iso→equiv biinv-int biinv-int
+    ( λ z → suc z
+    , λ z → predl z
+    , suc-predl
+    , λ z i → predl-suc z i
+    )
+
+def predl~predr (z : biinv-int) : path biinv-int (predl z) (predr z) =
+  λ j →
+  equiv-section/prop biinv-int biinv-int (λ z → suc z) (suc/equiv .snd)
+    (λ z → predl z, suc-predl)
+    (λ z → predr z, λ z i → suc-predr z i)
+    j .fst z
+
+def suc-predl~suc-predr (z : biinv-int) : [j i] biinv-int [
+  | i=0 → suc (predl~predr z j)
+  | i=1 → z
+  | j=0 → suc-predl z i
+  | j=1 → suc-predr z i
+  ]
+  =
+  λ j i →
+  equiv-section/prop biinv-int biinv-int (λ z → suc z) (suc/equiv .snd)
+    (λ z → predl z, suc-predl)
+    (λ z → predr z, λ z i → suc-predr z i)
+    j .snd z i
+
+-- proof that biinv-int is equivalent to int
+
+def fwd/pos : nat → biinv-int = elim [zero → zero | suc (_ → ih/n) → suc ih/n]
+
+def fwd/negsuc : nat → biinv-int = elim [zero → predl zero | suc (_ → ih/n) → predl ih/n]
+
+def fwd : int → biinv-int = elim [pos n → fwd/pos n | negsuc n → fwd/negsuc n]
+
+def bwd : biinv-int → int =
+  elim [
+  | zero → pos zero
+  | suc (z → ih/z) → isuc ih/z
+  | predl (z → ih/z) → pred ih/z
+  | predr (z → ih/z) → pred ih/z
+  | predl-suc (z → ih/z) i → pred-isuc ih/z i
+  | suc-predr (z → ih/z) i → isuc-pred ih/z i
+  ]
+
+def bwd-fwd/pos : (n : nat) → path _ (bwd (fwd/pos n)) (pos n) =
+  elim [
+  | zero → refl
+  | suc (_ → n/ih) → λ k → isuc (n/ih k)
+  ]
+
+def bwd-fwd/negsuc : (n : nat) → path _ (bwd (fwd/negsuc n)) (negsuc n) =
+  elim [
+  | zero → refl
+  | suc (_ → n/ih) → λ k → pred (n/ih k)
+  ]
+
+def bwd-fwd : (n : int) → path _ (bwd (fwd n)) n =
+  elim [pos n → bwd-fwd/pos n | negsuc n → bwd-fwd/negsuc n]
+
+def fwd/isuc/negsuc : (n : nat)
+  → path _ (fwd (isuc (negsuc n))) (suc (fwd (negsuc n)))
+  =
+  elim [
+  | zero → λ k → symm' biinv-int (λ j → suc-predl zero j) k
+  | suc n → λ k → symm' biinv-int (λ j → suc-predl (fwd/negsuc n) j) k
+  ]
+
+def fwd/isuc : (n : int) → path _ (fwd (isuc n)) (suc (fwd n)) =
+  elim [pos n → refl | negsuc n → fwd/isuc/negsuc n]
+
+def fwd/pred/pos : (n : nat)
+  → path _ (fwd (pred (pos n))) (predl (fwd/pos n))
+  =
+  elim [
+  | zero → refl
+  | suc n → λ k → symm' biinv-int (λ i → predl-suc (fwd/pos n) i) k
+  ]
+
+def fwd/pred : (n : int) → path _ (fwd (pred n)) (predl (fwd n)) =
+  elim [pos n → fwd/pred/pos n | negsuc n → refl]
+
+
+def fwd/pred-isuc/negsuc : (n : nat) → [i k] biinv-int [
+  | i=0 → trans biinv-int (fwd/pred (isuc (negsuc n))) (λ k → predl (fwd/isuc/negsuc n k)) k
+  | i=1 → fwd/negsuc n
+  | k=0 → fwd (pred-isuc (negsuc n) i)
+  | k=1 → predl-suc (fwd/negsuc n) i
+  ]
+  =
+  elim [
+  | zero → λ i k →
+    comp 0 1 (predl (symm'/filler biinv-int (λ i → suc-predl zero i) i k)) [
+    | i=0 m → trans/unit/l biinv-int (λ k → predl (fwd/isuc/negsuc zero k)) m k
+    | i=1 | k=0 → refl
+    | k=1 m → predl-adj zero m i
+    ]
+  | suc n → λ i k →
+    comp 0 1 (predl (symm'/filler biinv-int (λ i → suc-predl (fwd/negsuc n) i) i k)) [
+    | i=0 m → trans/unit/l biinv-int (λ k → predl (fwd/isuc/negsuc (suc n) k)) m k
+    | i=1 | k=0 → refl
+    | k=1 m → predl-adj (fwd/negsuc n) m i
+    ]
+  ]
+
+def fwd/pred-isuc : (n : int) → [i k] biinv-int [
+  | i=0 → trans biinv-int (fwd/pred (isuc n)) (λ k → predl (fwd/isuc n k)) k
+  | i=1 → fwd n
+  | k=0 → fwd (pred-isuc n i)
+  | k=1 → predl-suc (fwd n) i
+  ]
+  =
+  elim [
+  | pos n → λ i k →
+    comp 0 1 (symm'/filler biinv-int (λ i → predl-suc (fwd/pos n) i) i k) [
+    | i=0 m → trans/unit/r biinv-int (fwd/pred/pos (suc n)) m k
+    | i=1 | ∂[k] → refl
+    ]
+  | negsuc n → fwd/pred-isuc/negsuc n
+  ]
+
+def fwd/isuc-pred/pos : (n : nat) → [i k] biinv-int [
+  | i=0 → trans biinv-int (fwd/isuc (pred (pos n))) (λ k → suc (fwd/pred/pos n k)) k
+  | i=1 → fwd/pos n
+  | k=0 → fwd (isuc-pred (pos n) i)
+  | k=1 → suc-predl (fwd/pos n) i
+  ]
+  =
+  elim [
+  | zero → λ i k →
+    comp 0 1 (symm'/filler biinv-int (λ i → suc-predl zero i) i k) [
+    | i=0 m → trans/unit/r biinv-int (fwd/isuc/negsuc zero) m k
+    | i=1 | ∂[k] → refl
+    ]
+  | suc n → λ i k →
+    comp 0 1 (suc (symm'/filler biinv-int (λ i → predl-suc (fwd/pos n) i) i k)) [
+    | i=0 m → trans/unit/l biinv-int (λ k → suc (fwd/pred/pos (suc n) k)) m k
+    | i=1 | k=0 → refl
+    | k=1 m → suc-adj (fwd/pos n) m i
+    ]
+  ]
+
+
+def fwd/isuc-pred : (n : int) → [i k] biinv-int [
+  | i=0 → trans biinv-int (fwd/isuc (pred n)) (λ k → suc (fwd/pred n k)) k
+  | i=1 → fwd n
+  | k=0 → fwd (isuc-pred n i)
+  | k=1 → suc-predl (fwd n) i
+  ]
+  =
+  elim [
+  | pos n → fwd/isuc-pred/pos n
+  | negsuc n → λ i k →
+    comp 0 1 (symm'/filler biinv-int (λ i → suc-predl (fwd/negsuc n) i) i k) [
+    | i=0 m → trans/unit/r biinv-int (fwd/isuc/negsuc (suc n)) m k
+    | i=1 | ∂[k] → refl
+    ]
+  ]
+
+def fwd-bwd : (z : biinv-int) → path _ (fwd (bwd z)) z =
+  elim [
+  | zero → refl
+  | suc (z → z/ih) → trans biinv-int (fwd/isuc (bwd z)) (λ k → suc (z/ih k))
+  | predl (z → z/ih) → trans biinv-int (fwd/pred (bwd z)) (λ k → predl (z/ih k))
+  | predr (z → z/ih) → trans biinv-int (fwd/pred (bwd z)) (λ k → predl~predr (z/ih k) k)
+  | predl-suc (z → z/ih) i → λ k →
+    comp 0 1 (fwd/pred-isuc (bwd z) i k) [
+    | i=0 m →
+      trans biinv-int (fwd/pred (isuc (bwd z)))
+        (λ k → predl (trans/filler biinv-int (fwd/isuc (bwd z)) (λ k → suc (z/ih k)) m k)) k
+    | i=1 m → weak-connection/and biinv-int z/ih k m
+    | k=0 → refl
+    | k=1 m → predl-suc (z/ih m) i
+    ]
+  | suc-predr (z → z/ih) i → λ k →
+    comp 0 1 (fwd/isuc-pred (bwd z) i k) [
+    | i=0 m →
+      trans biinv-int (fwd/isuc (pred (bwd z)))
+        (λ k → suc (trans/filler biinv-int (fwd/pred (bwd z)) (λ k → predl~predr (z/ih k) k) m k)) k
+    | i=1 m → weak-connection/and biinv-int z/ih k m
+    | k=0 → refl
+    | k=1 m → suc-predl~suc-predr (z/ih m) m i
+    ]
+  ]
+
+def int-equiv-biinv-int : equiv int biinv-int =
+  iso→equiv _ _ (fwd,bwd,fwd-bwd,bwd-fwd)

--- a/library/paths/biinv-equiv.red
+++ b/library/paths/biinv-equiv.red
@@ -3,7 +3,7 @@ import basics.isotoequiv
 import basics.retract
 import basics.biinv-equiv
 
-def biinv-equiv/prop (A B : type) (f : A → B) : is-prop (is-biinv-equiv A B f) =
+def is-biinv-equiv/prop (A B : type) (f : A → B) : is-prop (is-biinv-equiv A B f) =
   λ (s0,r0) (s1,r1) i →
   let c = iso→equiv _ _ (biinv-equiv→iso _ _ (f,s0,r0)) .snd in
   (equiv-section/prop A B f c s0 s1 i, equiv-retraction/prop A B f c r0 r1 i)

--- a/library/paths/biinv-equiv.red
+++ b/library/paths/biinv-equiv.red
@@ -1,0 +1,9 @@
+import prelude
+import basics.isotoequiv
+import basics.retract
+import basics.biinv-equiv
+
+def biinv-equiv/prop (A B : type) (f : A → B) : is-prop (is-biinv-equiv A B f) =
+  λ (s0,r0) (s1,r1) i →
+  let c = iso→equiv _ _ (biinv-equiv→iso _ _ (f,s0,r0)) .snd in
+  (equiv-section/prop A B f c s0 s1 i, equiv-retraction/prop A B f c r0 r1 i)

--- a/library/paths/ha-equiv.red
+++ b/library/paths/ha-equiv.red
@@ -4,19 +4,6 @@ import basics.retract
 import basics.ha-equiv
 import paths.pi
 
-def symm/filler' (A : type) (p : 𝕀 → A) : [j i] A [
-  | j=0 → symm A p i
-  | j=1 → p 1
-  | i=0 → p 1
-  | i=1 → p j
-  ]
-  =
-  λ j i →
-  comp 0 1 (p 0) [
-  | i=0 | j=1 → p
-  | i=1 k → connection/and A p j k
-  ]
-
 -- this is actually an equivalence, but we don't need that
 def lcoh/retract-of-fiber-path (A B : type) (f : A → B) (c : is-equiv A B f)
   (g : B → A) (f-g : (b : _) → path _ (f (g b)) b)
@@ -30,7 +17,7 @@ def lcoh/retract-of-fiber-path (A B : type) (f : A → B) (c : is-equiv A B f)
       comp 1 0 (adj a j i) [
       | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
       | i=1 | j=0 → refl
-      | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+      | j=1 k → weak-connection/or-not B (λ v → f-g (f a) v) i k
       ]
     )
   , λ p →
@@ -39,7 +26,7 @@ def lcoh/retract-of-fiber-path (A B : type) (f : A → B) (c : is-equiv A B f)
       comp 0 1 (p a i .snd j) [
       | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
       | i=1 | j=0 → refl
-      | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+      | j=1 k → weak-connection/or-not B (λ v → f-g (f a) v) i k
       ]
     )
   , λ (g-f,adj) k →
@@ -49,13 +36,13 @@ def lcoh/retract-of-fiber-path (A B : type) (f : A → B) (c : is-equiv A B f)
         comp 1 k (adj a j i) [
         | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
         | i=1 | j=0 → refl
-        | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+        | j=1 k → weak-connection/or-not B (λ v → f-g (f a) v) i k
         ]
       in
       comp k 1 capk [
       | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
       | i=1 | j=0 → refl
-      | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+      | j=1 k → weak-connection/or-not B (λ v → f-g (f a) v) i k
       ]
     )
   )

--- a/library/paths/ha-equiv.red
+++ b/library/paths/ha-equiv.red
@@ -72,7 +72,7 @@ def equiv-lcoh/prop (A B : type) (f : A → B) (c : is-equiv A B f)
          (contr→prop (fiber A B f (f a)) (c (f a)))
          (g (f a), f-g (f a)) (a, refl)))
 
-def ha-equiv/prop (A B : type) (f : A → B) : is-prop (is-ha-equiv A B f) =
+def is-ha-equiv/prop (A B : type) (f : A → B) : is-prop (is-ha-equiv A B f) =
   λ (g0,f-g0,g0-f,adj0) (g1,f-g1,g1-f,adj1) i →
   let c = iso→equiv _ _ (f,g0,f-g0,g0-f) .snd in
   let p = equiv-section/prop A B f c (g0,f-g0) (g1,f-g1) in

--- a/library/paths/ha-equiv.red
+++ b/library/paths/ha-equiv.red
@@ -1,0 +1,84 @@
+import prelude
+import basics.isotoequiv
+import basics.retract
+import basics.ha-equiv
+import paths.pi
+
+def symm/filler' (A : type) (p : 𝕀 → A) : [j i] A [
+  | j=0 → symm A p i
+  | j=1 → p 1
+  | i=0 → p 1
+  | i=1 → p j
+  ]
+  =
+  λ j i →
+  comp 0 1 (p 0) [
+  | i=0 | j=1 → p
+  | i=1 k → connection/and A p j k
+  ]
+
+-- this is actually an equivalence, but we don't need that
+def lcoh/retract-of-fiber-path (A B : type) (f : A → B) (c : is-equiv A B f)
+  (g : B → A) (f-g : (b : _) → path _ (f (g b)) b)
+  : retract
+    (lcoh A B f g f-g)
+    ((a : A) → path (fiber A B f (f a)) (g (f a), f-g (f a)) (a, refl))
+  =
+  ( λ (g-f,adj) a i →
+    ( g-f a i
+    , λ j →
+      comp 1 0 (adj a j i) [
+      | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
+      | i=1 | j=0 → refl
+      | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+      ]
+    )
+  , λ p →
+    ( λ a i → p a i .fst
+    , λ a j i →
+      comp 0 1 (p a i .snd j) [
+      | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
+      | i=1 | j=0 → refl
+      | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+      ]
+    )
+  , λ (g-f,adj) k →
+    ( g-f
+    , λ a j i →
+      let capk : B =
+        comp 1 k (adj a j i) [
+        | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
+        | i=1 | j=0 → refl
+        | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+        ]
+      in
+      comp k 1 capk [
+      | i=0 k → symm/filler B (λ n → f-g (f a) n) j k
+      | i=1 | j=0 → refl
+      | j=1 k → symm/filler' B (λ v → f-g (f a) v) i k
+      ]
+    )
+  )
+
+def equiv-lcoh/prop (A B : type) (f : A → B) (c : is-equiv A B f)
+  (g : B → A) (f-g : (b : _) → path _ (f (g b)) b)
+  : is-prop (lcoh A B f g f-g)
+  =
+  retract/hlevel prop _ _
+    (lcoh/retract-of-fiber-path A B f c g f-g)
+    (pi/hlevel prop A _
+      (λ a →
+       prop→set (fiber A B f (f a))
+         (contr→prop (fiber A B f (f a)) (c (f a)))
+         (g (f a), f-g (f a)) (a, refl)))
+
+def ha-equiv/prop (A B : type) (f : A → B) : is-prop (is-ha-equiv A B f) =
+  λ (g0,f-g0,g0-f,adj0) (g1,f-g1,g1-f,adj1) i →
+  let c = iso→equiv _ _ (f,g0,f-g0,g0-f) .snd in
+  let p = equiv-section/prop A B f c (g0,f-g0) (g1,f-g1) in
+  let q = prop→prop-over (λ i → lcoh A B f (p i .fst) (p i .snd))
+           (equiv-lcoh/prop A B f c g1 f-g1) (g0-f,adj0) (g1-f,adj1)
+  in
+  (p i .fst, p i .snd, q i .fst, q i .snd)
+
+

--- a/library/prelude/connection.red
+++ b/library/prelude/connection.red
@@ -1,3 +1,5 @@
+import prelude.path
+
 def connection/or
   (A : type)
   (p : 𝕀 → A)
@@ -123,4 +125,20 @@ def weak-connection/and
   | i=1 → face j
   | j=1 → face i
   ]
+
+def weak-connection/or-not -- i \/ ~j
+  (A : type)
+  (p : 𝕀 → A)
+  : [i j] A [
+  | i=0 → symm A p j
+  | i=1 | j=0 → p 1
+  | j=1 → p i
+  ]
+  =
+  λ i j →
+  comp 0 1 (p 0) [
+  | j=0 | i=1 → p
+  | j=1 k → connection/and A p i k
+  ]
+
 

--- a/library/prelude/hlevel.red
+++ b/library/prelude/hlevel.red
@@ -41,6 +41,9 @@ def type/groupoid = type/of-level groupoid
 
 -- lower hlevels imply higher hlevels
 
+def contr→prop (A : type) (A/contr : is-contr A) : is-prop A =
+  λ a a' → trans A (A/contr .snd a) (symm A (A/contr .snd a'))
+
 def prop→set (A : type) (A/prop : is-prop A) : is-set A =
   λ a b p q i j →
   comp 0 1 a [
@@ -51,8 +54,7 @@ def prop→set (A : type) (A/prop : is-prop A) : is-set A =
 
 def raise-hlevel : (l : hlevel) (A : type) → has-hlevel l A → has-hlevel (hsuc l) A =
   elim [
-  | contr → λ A A/level a a' →
-    trans A (A/level .snd a) (symm A (A/level .snd a'))
+  | contr → contr→prop
   | hsuc l →
     elim l [
     | contr → prop→set

--- a/library/prelude/path.red
+++ b/library/prelude/path.red
@@ -52,6 +52,15 @@ def symm (A : type) (p : 𝕀 → A) : path A (p 1) (p 0) =
 def symm/unit (A : type) (a : A) : path (path _ a a) refl (symm _ (λ _ → a)) =
   symm/filler _ (λ _ → a)
 
+def symm'/filler (A : type) (p : 𝕀 → A) (j i : 𝕀) : A =
+  comp 1 j (p 1) [
+  | i=0 → refl
+  | i=1 → p
+  ]
+
+def symm' (A : type) (p : 𝕀 → A) : path A (p 1) (p 0) =
+  symm'/filler _ p 0
+
 def trans/filler (A : type) (p : 𝕀 → A) (q : [i] A [i=0 → p 1]) (j i : 𝕀) : A =
   comp 0 j (p i) [
   | i=0 → refl
@@ -60,7 +69,6 @@ def trans/filler (A : type) (p : 𝕀 → A) (q : [i] A [i=0 → p 1]) (j i : �
 
 def trans (A : type) (p : 𝕀 → A) (q : [i] A [i=0 → p 1]) : path _ (p 0) (q 1) =
   trans/filler _ p q 1
-
 
 def trans/unit/r (A : type) (p : 𝕀 → A) : path (path _ (p 0) (p 1)) p (trans _ p (λ _ → p 1)) =
   trans/filler _ p (λ _ → p 1)
@@ -77,7 +85,6 @@ def trans/unit/l (A : type) (p : 𝕀 → A) : path (path _ (p 0) (p 1)) p (tran
   | i=0 → refl
   | i=1 → p
   ]
-
 
 -- This proof gets simpler when dead tubes are deleted!
 def trans/sym/r (A : type) (p : 𝕀 → A) : path (path _ (p 0) (p 0)) refl (trans _ p (symm _ p)) =


### PR DESCRIPTION
Right now I've proven that `int` is equivalent to `biinv-int`, which is generated by a point and a bi-invertible endomap (i.e., a map with a left and right inverse). This is easier than proving `int` is equivalent to the HIT generated by a point and a half-adjoint equivalence (the way it is typically presented), because `biinv-int` only has 0- and 1-dimensional generators.

However, I suspect it will be straightforward to show that `biinv` is equivalent to the half-adjoint version just using the standard theorems that the different definitions of equivalence are interchangeable. ETA: Maybe not.