### PR TITLE
Use Stdlib instead of Pervasives.

### DIFF
--- a/src/core/Name.ml
+++ b/src/core/Name.ml
@@ -15,7 +15,7 @@ let fresh () =
   named None
 
 let compare =
-  Pervasives.compare
+  Stdlib.compare
 
 let name i =
   match Hashtbl.find names i with


### PR DESCRIPTION
OCaml's new `Pervasives` is called `Stdlib`.