### PR TITLE
Enable type inference for Menhir.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
 (lang dune 2.1.1)
-(using menhir 1.0) ; menhir versions are datestamps, e.g. "20190924", so this is a placeholder
+(using menhir 2.0) ; required for dune to pass --infer to menhir


### PR DESCRIPTION
This is already useful now, and will be more useful in the future (Menhir's upcoming new code back-end will require `--infer`).